### PR TITLE
Fixed 4d seg slicing index initialization issue

### DIFF
--- a/Logic/Framework/GenericImageData.cxx
+++ b/Logic/Framework/GenericImageData.cxx
@@ -350,6 +350,9 @@ GenericImageData
   seg_wrapper->InitializeToWrapper(m_MainImageWrapper, (LabelType) 0);
   seg_wrapper->SetImage4D(imgLabel);
 
+  // Segmentation and Main Image should have same slice index
+  seg_wrapper->SetSliceIndex(m_MainImageWrapper->GetSliceIndex());
+
   // Update filenames
   seg_wrapper->SetFileName(io->GetFileNameOfNativeImage());
   seg_wrapper->SetDefaultNickname(this->GenerateNickname(LABEL_ROLE));


### PR DESCRIPTION
Without this line of code, the segmentation slice index was initialized as (0,0,0), which caused wrong slices being rendered on segmentation loading. 