### PR TITLE
Add custom contrast window presets (window level and window width)

### DIFF
--- a/Common/ContrastXML.cxx
+++ b/Common/ContrastXML.cxx
@@ -1,0 +1,150 @@
+/*=========================================================================
+
+  Program:   ITK-SNAP
+  Language:  C++
+  
+  This file was created as part of the added functionality of the custom windowing.
+  We have added the option to set a custom contrast window preset using Contrast Menu.
+
+  This file is mostly based on Common\Registry.cxx
+  
+=========================================================================*/
+#include "ContrastXML.h"
+#include "itkXMLFile.h"
+
+#include "itksys/SystemTools.hxx"
+#include "IRISException.h"
+
+#if defined(_MSC_VER)
+#pragma warning ( disable : 4786 )
+#endif
+#include <Registry.cxx>
+
+using namespace std;
+
+
+int ContrastXMLFileReader::CanReadFile(const char* name)
+{
+    return GenericXMLFileReader::CanReadFile(name);
+}
+
+std::vector<std::shared_ptr<PresetStruct>> ContrastXMLFileReader::getPresetStack() const
+{
+  return m_PresetStack;
+}
+
+void ContrastXMLFileReader::StartElement(const char* name, const char** atts)
+{
+    // If this is the root-level element <contrast>, it can be ignored
+    if (strcmpi(name, "contrast") == 0)
+    {
+        return;
+    }
+
+    // Read the attributes into a map
+    typedef std::map<std::string, std::string> AttributeMap;
+    typedef AttributeMap::const_iterator AttrIter;
+    AttributeMap attrmap;
+
+    for (int i = 0; atts[i] != nullptr && atts[i + 1] != nullptr; i += 2)
+        attrmap[itksys::SystemTools::LowerCase(atts[i])] = atts[i + 1];
+
+    // Process tags
+    if (strcmpi(name, "preset") == 0)
+    {
+        const AttrIter itKey = attrmap.find("key");
+        if (itKey == attrmap.end())
+            throw IRISException("Missing 'key' attribute to <preset> element");
+
+        const auto preset_name = itKey->second;
+
+        // Create a new preset and place it on the stack
+        m_PresetStack.push_back(std::make_shared<PresetStruct>(PresetStruct{preset_name}));
+    }
+    else if (strcmpi(name, "contrastProperty") == 0)
+    {
+        const AttrIter itKey = attrmap.find("key");
+        if (itKey == attrmap.end())
+            throw IRISException("Missing 'key' attribute to <contrastProperty> element");
+
+        const AttrIter itValue = attrmap.find("value");
+        if (itValue == attrmap.end())
+            throw IRISException("Missing 'value' attribute to <contrastProperty> element");
+
+        const auto property_name = itKey->second;
+        const auto property_value = itValue->second;
+
+        if(property_name == "Window")
+        {
+            m_PresetStack.back()->window = stod(property_value);
+        }
+        if(property_name == "Level")
+        {
+          m_PresetStack.back()->level = stod(property_value);
+        }
+    }
+    else
+        throw IRISException("Unknown XML element <%s>", name);
+}
+
+void ContrastXMLFileReader::EndElement(const char* name)
+{
+}
+
+void ContrastXMLFileReader::CharacterDataHandler(const char* inData, int inLength)
+{
+}
+
+
+void
+Contrast
+::Clear()
+{
+    m_PresetMap.clear();
+}
+
+std::vector<std::string>
+Contrast::GetPresetNames()
+{
+    // get all keys from m_PresetMap and sort if needed
+    std::vector<std::string> presets;
+    for (const auto& map_entry : m_PresetMap)
+    {
+        presets.push_back(map_entry.first); // have to get all keys
+    }
+
+    return presets;
+}
+
+double Contrast::GetLevel(const std::string& tissue)
+{
+    return m_PresetMap.at(tissue).level;
+}
+
+double Contrast::GetWindow(const std::string& tissue)
+{
+    return m_PresetMap.at(tissue).window;
+}
+
+
+Contrast
+::Contrast()
+= default;
+
+Contrast::
+~Contrast()
+= default;
+
+void Contrast::ReadFromCustomContrastXMLFile(const char* pathname, SmartPtr<ContrastXMLFileReader>& reader)
+{
+    reader->SetOutputObject(this);
+    reader->SetFilename(pathname);
+
+    reader->GenerateOutputInformation();
+    
+    // check if presets are populated
+    for (const auto& preset : reader->getPresetStack())
+    {
+        m_PresetMap.insert(std::pair<std::string, PresetStruct>(preset->preset_name, *preset));
+    }
+}

--- a/Common/ContrastXML.h
+++ b/Common/ContrastXML.h
@@ -1,0 +1,101 @@
+/*=========================================================================
+
+  Program:   ITK-SNAP
+  Language:  C++
+  
+  This file was created as part of the added functionality of the custom windowing.
+  We have added the option to set a custom contrast window preset using Contrast Menu.
+
+  This file is mostly based on Common\Registry.h
+  
+=========================================================================*/
+#ifndef __Contrast_h_
+#define __Contrast_h_
+
+#ifdef _MSC_VER
+# pragma warning(disable:4786)  // '255' characters in the debug information
+#endif //_MSC_VER
+
+#include <list>
+#include <map>
+#include <string>
+#include <cstdarg>
+#include <iomanip>
+
+#include <itksys/SystemTools.hxx>
+#include "itkXMLFile.h"
+
+#include "IRISException.h"
+
+struct PresetStruct
+{
+  std::string preset_name;
+  double level;
+  double window;
+};
+
+class Contrast;
+
+/** Reader for XML files */
+class ContrastXMLFileReader : public itk::XMLReader<Contrast>
+{
+public:
+
+    irisITKObjectMacro(ContrastXMLFileReader, itk::XMLReader<Contrast>)
+    int CanReadFile(const char* name) ITK_OVERRIDE;
+
+    std::vector<std::shared_ptr<PresetStruct>> getPresetStack() const;
+
+protected:
+
+    ContrastXMLFileReader()
+    = default;
+
+    void StartElement(const char* name, const char** atts) ITK_OVERRIDE;
+    void EndElement(const char* name) ITK_OVERRIDE;
+    void CharacterDataHandler(const char* inData, int inLength) ITK_OVERRIDE;
+
+    static int strcmpi(const char* str1, const char* str2)
+    {
+        return itksys::SystemTools::Strucmp(str1, str2);
+    }
+    
+    // The preset stack
+    std::vector<std::shared_ptr<PresetStruct>> m_PresetStack;
+};
+
+/**
+ * \class Contrast
+ * \brief A tree of key-value pair maps
+ */
+class Contrast final
+{
+public:
+    /** Constructor initializes an empty contrast */
+    Contrast();
+
+    /** Destructor */
+    virtual ~Contrast();
+
+    /** Get a list of preset names*/
+    std::vector<std::string> GetPresetNames();
+
+    /** Get a level value*/
+    double GetLevel(const std::string& tissue);
+
+    /** Get a window value*/
+    double GetWindow(const std::string& tissue);
+
+    /** Empty the contents of the contrast */
+    void Clear();
+
+    /** Read from XML file */
+    void ReadFromCustomContrastXMLFile(const char* pathname, SmartPtr<ContrastXMLFileReader>& reader);
+
+private:
+    
+    /** A hash table for the presets */
+    std::map<std::string, PresetStruct> m_PresetMap;
+};
+
+#endif

--- a/Common/Registry.cxx
+++ b/Common/Registry.cxx
@@ -50,6 +50,20 @@
 
 using namespace std;
 
+namespace GenericXMLFileReader
+{
+    static int CanReadFile(const char *name)
+    {
+        if ( !itksys::SystemTools::FileExists(name)
+            || itksys::SystemTools::FileIsDirectory(name)
+            || itksys::SystemTools::FileLength(name) == 0 )
+        {
+            return 0;
+        }
+
+        return 1;
+    }
+}
 
 
 /** Reader for XML files */
@@ -79,14 +93,7 @@ protected:
 
 int RegistryXMLFileReader::CanReadFile(const char *name)
 {
-  if ( !itksys::SystemTools::FileExists(name)
-       || itksys::SystemTools::FileIsDirectory(name)
-       || itksys::SystemTools::FileLength(name) == 0 )
-    {
-    return 0;
-    }
-
-  return 1;
+    return GenericXMLFileReader::CanReadFile(name);
 }
 
 void RegistryXMLFileReader::StartElement(const char *name, const char **atts)

--- a/ContrastSettings.xml
+++ b/ContrastSettings.xml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE contrast [
+<!ELEMENT contrast (contrastProperty*,preset*)>
+<!ELEMENT preset (contrastProperty*,preset*)>
+<!ELEMENT contrastProperty EMPTY>
+<!ATTLIST preset key CDATA #REQUIRED>
+<!ATTLIST contrastProperty key CDATA #REQUIRED>
+<!ATTLIST contrastProperty value CDATA #REQUIRED>
+]>
+<!--
+The contrast enhancement values are specifically prepared for CT analysis. 
+They are directly taken from: https://radiopaedia.org/articles/windowing-ct.
+
+To add a new preset, complete the file with the structure as in the examples below. 
+At "preset" change "key" to the name of the preset to be added, and at "contrastProperty" set custom "value".
+-->
+<contrast>
+  <preset key="Abdomen-SoftTissues" >
+    <contrastProperty key="Window" value="400" />
+    <contrastProperty key="Level" value="50" />
+  </preset>
+  <preset key="Brain" >
+    <contrastProperty key="Window" value="80" />
+    <contrastProperty key="Level" value="40" />
+  </preset>
+  <preset key="Lungs" >
+    <contrastProperty key="Window" value="1500" />
+    <contrastProperty key="Level" value="-600" />
+  </preset>
+  <preset key="Mediastinum" >
+    <contrastProperty key="Window" value="350" />
+    <contrastProperty key="Level" value="50" />
+  </preset>
+  <preset key="Spine-Bone" >
+    <contrastProperty key="Window" value="1800" />
+    <contrastProperty key="Level" value="400" />
+  </preset>
+</contrast>

--- a/GUI/Model/GlobalUIModel.cxx
+++ b/GUI/Model/GlobalUIModel.cxx
@@ -399,6 +399,12 @@ void GlobalUIModel::ResetContrastAllLayers()
     }
 }
 
+void GlobalUIModel::AdjustContrastAllLayers(double level, double window)
+{
+    IntensityCurveModel *curve_model = GetIntensityCurveModel();
+    curve_model->OnAdjustCustomContrast(level, window);
+}
+
 void GlobalUIModel::ToggleOverlayVisibility()
 {
   // Are we in tiled mode or in stack mode?
@@ -509,6 +515,7 @@ void GlobalUIModel::LoadUserPreferences()
   // Read the appearance settings
   m_AppearanceSettings->LoadFromRegistry(
         si->Folder("UserInterface.Appearance"));
+
 
   // Read the default behaviors
   dbs->ReadFromRegistry(

--- a/GUI/Model/GlobalUIModel.h
+++ b/GUI/Model/GlobalUIModel.h
@@ -326,8 +326,11 @@ public:
   /** Auto-adjust contrast in all image layers */
   void AutoContrastAllLayers();
 
-  /** Auto-adjust contrast in all image layers */
+  /** Reset contrast in all image layers */
   void ResetContrastAllLayers();
+
+  /** Adjust custom contrast in all image layers */
+  void AdjustContrastAllLayers(double level, double window);
 
   /** A function for switching between segmentation layers when there multiple */
   void CycleSelectedSegmentationLayer(int direction);

--- a/GUI/Model/IntensityCurveModel.cxx
+++ b/GUI/Model/IntensityCurveModel.cxx
@@ -637,6 +637,15 @@ void IntensityCurveModel::OnAutoFitWindow()
   dmp->AutoFitContrast();
 }
 
+void IntensityCurveModel::OnAdjustCustomContrast(double custom_level, double custom_window)
+{
+  int index_level = 2;
+  int index_window = 3;
+
+  SetIntensityRangeIndexedValue(index_level, custom_level);
+  SetIntensityRangeIndexedValue(index_window, custom_window);
+}
+
 bool
 IntensityCurveModel
 ::GetHistogramBinSizeValueAndRange(

--- a/GUI/Model/IntensityCurveModel.h
+++ b/GUI/Model/IntensityCurveModel.h
@@ -172,6 +172,7 @@ public:
       IntensityRangePropertyType index) const;
 
   void OnAutoFitWindow();
+  void OnAdjustCustomContrast(double custom_level, double custom_window);
 protected:
 
   IntensityCurveModel();

--- a/GUI/Qt/Windows/MainControlPanel.cxx
+++ b/GUI/Qt/Windows/MainControlPanel.cxx
@@ -184,6 +184,7 @@ MainControlPanel::MainControlPanel(MainImageWindow *parent) :
 void MainControlPanel::SetModel(GlobalUIModel *model)
 {
   m_Model = model;
+
   ui->pageCursorInspector->SetModel(m_Model->GetCursorInspectionModel());
   ui->pageZoomInspector->SetModel(m_Model);
   ui->pageDisplayInspector->SetModel(m_Model->GetDisplayLayoutModel());

--- a/GUI/Qt/Windows/MainControlPanel.h
+++ b/GUI/Qt/Windows/MainControlPanel.h
@@ -5,6 +5,7 @@
 
 class LabelSelectionButton;
 class LabelSelectionPopup;
+class IntensityCurveModel;
 
 namespace Ui {
 class MainControlPanel;

--- a/GUI/Qt/Windows/MainImageWindow.cxx
+++ b/GUI/Qt/Windows/MainImageWindow.cxx
@@ -72,6 +72,7 @@
 #include <InterpolateLabelsDialog.h>
 #include "RegistrationDialog.h"
 #include "DistributedSegmentationDialog.h"
+#include "ContrastXML.h"
 
 #include <QAbstractListModel>
 #include <QItemDelegate>
@@ -89,6 +90,7 @@
 #include <QShortcut>
 
 #include <QTextStream>
+#include <itksys/SystemTools.hxx>
 
 QString read_tooltip_qt(const QString &filename)
 {
@@ -96,7 +98,7 @@ QString read_tooltip_qt(const QString &filename)
   file.open(QFile::ReadOnly);
   QTextStream ts(&file);
   QString result = ts.readAll();
-  file.close();;
+  file.close();
 
   return result;
 }
@@ -170,6 +172,7 @@ MainImageWindow::MainImageWindow(QWidget *parent) :
     m_Model(NULL)
 {
   ui->setupUi(this);
+  m_CustomContrast = new Contrast();
 
   // Group mutually exclusive actions into action groups
   QActionGroup *grpToolbarMain = new QActionGroup(this);
@@ -646,6 +649,7 @@ void MainImageWindow::ShowFirstTime()
 
   // Also make sure the other elements look right before showing the window
   this->UpdateRecentMenu();
+  this->UpdateContrastMenu();
   this->UpdateRecentProjectsMenu();
   this->UpdateWindowTitle();
   this->UpdateLayerLayoutActions();
@@ -938,6 +942,38 @@ void MainImageWindow::CreateRecentMenu(
   submenu->menuAction()->setVisible(recent.size() > 0);
 }
 
+std::string MainImageWindow::GetContrastXMLFilePath()
+{
+    char rawPath[MAX_PATH];
+    GetModuleFileNameA(nullptr, rawPath, MAX_PATH);
+    auto exePath = std::string(rawPath);
+    auto filenameDir = exePath.substr(0, exePath.find_last_of("\\/"));
+    auto filePath = filenameDir + "\\ContrastSettings.xml";
+    return filePath;
+}
+
+void MainImageWindow::CreateContrastMenu(QMenu *submenu,
+                                         const char *slot)
+{ 
+    const auto filePath = GetContrastXMLFilePath();
+
+    SmartPtr<ContrastXMLFileReader> reader = ContrastXMLFileReader::New();
+    if (reader->CanReadFile(filePath.c_str()))
+    {
+        // Read the XML with custom contrast settings
+        m_CustomContrast->ReadFromCustomContrastXMLFile(filePath.c_str(), reader);
+
+        auto presetNames = m_CustomContrast->GetPresetNames();
+
+        for (auto presetName : presetNames)
+        {
+            QAction* action = submenu->addAction(from_utf8(presetName));
+            activateOnFlag(action, m_Model, UIF_BASEIMG_LOADED);
+            connect(action, SIGNAL(triggered(bool)), this, slot);
+        }
+    }   
+}
+
 void MainImageWindow::UpdateRecentMenu()
 {
   // Create recent menus for various history categories
@@ -952,6 +988,12 @@ void MainImageWindow::UpdateRecentMenu()
 
   this->CreateRecentMenu(ui->menuAddSegmentation_Recent, "LabelImage", false, 5,
                          SLOT(LoadAnotherRecentSegmentationActionTriggered()));
+}
+
+void MainImageWindow::UpdateContrastMenu()
+{
+  // Create contrast menu for various preset categories
+  this->CreateContrastMenu(ui->menuContrast, SLOT(LoadContrastActionTriggered()));
 }
 
 void MainImageWindow::UpdateRecentProjectsMenu()
@@ -1404,6 +1446,17 @@ void MainImageWindow::LoadRecentSegmentationActionTriggered()
   QAction *action = qobject_cast<QAction *>(sender());
   QString file = action->text();
   LoadRecentSegmentation(file, false);
+}
+
+void MainImageWindow::LoadContrastActionTriggered()
+{
+  // Get the filename that wants to be loaded
+  QAction *action = qobject_cast<QAction *>(sender());
+  QString preset = action->text();
+  auto level = m_CustomContrast->GetLevel(preset.toStdString());
+  auto window = m_CustomContrast->GetWindow(preset.toStdString());
+
+  m_Model->AdjustContrastAllLayers(level, window);
 }
 
 void MainImageWindow::LoadAnotherRecentSegmentationActionTriggered()
@@ -2130,6 +2183,7 @@ void MainImageWindow::on_actionResetContrastGlobal_triggered()
   // This triggers the autocontrast option for all layers.
   m_Model->ResetContrastAllLayers();
 }
+
 
 void MainImageWindow::DoUpdateCheck(bool quiet)
 {

--- a/GUI/Qt/Windows/MainImageWindow.h
+++ b/GUI/Qt/Windows/MainImageWindow.h
@@ -28,6 +28,8 @@
 #define MAINIMAGEWINDOW_H
 
 #include <QMainWindow>
+
+#include "ContrastXML.h"
 #include "GlobalState.h"
 #include "SNAPCommon.h"
 
@@ -134,6 +136,7 @@ public slots:
   void LoadRecentActionTriggered();
   void LoadRecentOverlayActionTriggered();
   void LoadRecentSegmentationActionTriggered();
+  void LoadContrastActionTriggered();
   void LoadAnotherRecentSegmentationActionTriggered();
   void LoadRecentProjectActionTriggered();
   void LoadAnotherDicomActionTriggered();
@@ -336,13 +339,18 @@ protected:
 
 private:
 
+  static std::string GetContrastXMLFilePath();
+
   void CreateRecentMenu(QMenu *submenu,
                         const char *history_category,
                         bool use_global_history,
                         int max_items, const char *slot,
                         bool use_shortcut = false, int shortcut_modifier = 0);
 
+  void CreateContrastMenu(QMenu *submenu, const char *slot);
+
   void UpdateRecentMenu();
+  void UpdateContrastMenu();
   void UpdateWindowTitle();
   void UpdateProjectMenuItems();
   void UpdateRecentProjectsMenu();
@@ -413,6 +421,8 @@ private:
   RegistrationDialog *m_RegistrationDialog;
 
   DistributedSegmentationDialog *m_DSSDialog;
+
+  Contrast *m_CustomContrast;
 
   // A timer used to animate components
   QTimer *m_AnimateTimer;

--- a/GUI/Qt/Windows/MainImageWindow.ui
+++ b/GUI/Qt/Windows/MainImageWindow.ui
@@ -535,6 +535,7 @@ color:rgb(103, 103, 103);
      <addaction name="separator"/>
      <addaction name="actionAutoContrastGlobal"/>
      <addaction name="actionResetContrastGlobal"/>
+     <addaction name="separator"/>
     </widget>
     <addaction name="separator"/>
     <addaction name="actionLayerInspector"/>


### PR DESCRIPTION
Added option in the menu to automatically set custom contrast window presets. You can add your own default window level and window width in ContrastSettings.xml. It looks like this:
![image](https://user-images.githubusercontent.com/105724715/169017364-8e987118-fbcd-4401-8469-4c11dedde7fd.png)
