### PR TITLE
hotfix: fixed a windows build error

### DIFF
--- a/GUI/Qt/Components/FileChooserPanelWithHistory.cxx
+++ b/GUI/Qt/Components/FileChooserPanelWithHistory.cxx
@@ -630,7 +630,7 @@ void FileChooserPanelWithHistory::setCurrentFormatText(const QString &format)
 #endif
 }
 
-bool FileChooserPanelWithHistory::isFilenameNonAscii(const QString &)
+bool FileChooserPanelWithHistory::isFilenameNonAscii(const QString &text)
 {
 #ifdef WIN32
   for(int i = 0; i < text.length(); i++)


### PR DESCRIPTION
Error was caused by missing parameter name for the windows build.