### PR TITLE
Fix Linux build when sys_siglist is not declared

### DIFF
--- a/GUI/Qt/main.cxx
+++ b/GUI/Qt/main.cxx
@@ -71,7 +71,7 @@ using namespace std;
 void SegmentationFaultHandler(int sig)
 {
   cerr << "*************************************" << endl;
-  cerr << "ITK-SNAP: " << sys_siglist[sig] << endl;
+  cerr << "ITK-SNAP: " << strsignal(sig) << endl;
   cerr << "BACKTRACE: " << endl;
   void *array[50];
   int nsize = backtrace(array, 50);


### PR DESCRIPTION
Hi, 
Thanks for ITK-SNAP - the quickest image visualization and segmentation tool out there.

When building the on more recent gcc versions (e.g. gcc 11.2.0 bundled with Ubuntu 22.04),
the Linux build fails with:
```
itksnap/src/GUI/Qt/main.cxx:74:27: error: ‘sys_siglist’ was not declared in this scope
   74 |   cerr << "ITK-SNAP: " << sys_siglist[sig] << endl;
      |                           ^~~~~~~~~~~
```

In the docs, the sys_siglist array is marked as non-standard, deprecated, and from glibc version > 2.32 is also no longer exported).
This commit fixes the compilation by replacing the direct `sys_siglist` array access with calling the `strsignal` function.

For more info, see:
https://man7.org/linux/man-pages/man3/strsignal.3.html
It has been in the POSIX standard since 2008:
https://pubs.opengroup.org/onlinepubs/9699919799/functions/strsignal.html