### PR TITLE
Fixed Cartesian DICOM reorienting issue and a seg fault fix

### DIFF
--- a/CMake/standalone.cmake
+++ b/CMake/standalone.cmake
@@ -43,6 +43,7 @@ FIND_PACKAGE(ITK 5.2.1 REQUIRED COMPONENTS
   ITKImageNoise
   ITKImageStatistics
   ITKLabelMap
+  ITKLabelVoting
   ITKLevelSets
   ITKMathematicalMorphology
   ITKMesh

--- a/GUI/Renderer/Generic3DRenderer.cxx
+++ b/GUI/Renderer/Generic3DRenderer.cxx
@@ -733,6 +733,7 @@ public:
   vtkSmartPointer<vtkVolumeProperty> Property;
   vtkSmartPointer<vtkPiecewiseFunction> OpacityCurve;
   vtkSmartPointer<vtkPiecewiseFunction> GradientCurve;
+  vtkSmartPointer<vtkRenderer> Renderer;
 
   // Update time on the curve
   itk::ModifiedTimeType CurveUpdateTime = 0;
@@ -740,7 +741,11 @@ public:
 
 protected:
   VolumeAssembly() {}
-  virtual ~VolumeAssembly() {}
+  virtual ~VolumeAssembly()
+  {
+    // Remove this from the renderer when owner gets unloaded to avoid seg fault
+    Renderer->RemoveViewProp(this->Volume);
+  }
 };
 
 void Generic3DRenderer::UpdateVolumeCurves(ImageWrapperBase *layer, VolumeAssembly *va)
@@ -856,6 +861,8 @@ void Generic3DRenderer::UpdateVolumeRendering()
       va->Volume = vtkSmartPointer<vtkVolume>::New();
       va->Volume->SetMapper(va->Mapper);
       va->Volume->SetProperty(va->Property);
+
+      va->Renderer = this->m_Renderer; // when image get removed, volume can remove itself
 
       this->m_Renderer->AddViewProp(va->Volume);
       layer->SetUserData("volume", va);

--- a/Logic/Framework/GenericImageData.cxx
+++ b/Logic/Framework/GenericImageData.cxx
@@ -710,7 +710,13 @@ void GenericImageData::RemoveImageWrapper(LayerRole role,
   WrapperIterator it =
       std::find(wrappers.begin(), wrappers.end(), wrapper);
   if(it != wrappers.end())
+    {
+    auto *volume = it->GetPointer()->GetUserData("volume");
+    if (volume)
+      it->GetPointer()->RemoveUserData("volume");
+
     wrappers.erase(it);
+    }
 
   // Fire the layer change event
   this->InvokeEvent(LayerChangeEvent());

--- a/Logic/ImageWrapper/GuidedNativeImageIO.cxx
+++ b/Logic/ImageWrapper/GuidedNativeImageIO.cxx
@@ -618,13 +618,10 @@ GuidedNativeImageIO
 			for (unsigned int i = 0; i < 4; ++i)
 				m_IOBase->SetOrigin(i, 0.0);
 
-			// Set direction to LPS
-			for (unsigned int i = 0; i < 3; ++i)
-				{
-				std::vector<double> ecd_dir = {0.0, 0.0, 0.0, 0.0};
-				ecd_dir[i] = -1.0;
-				m_IOBase->SetDirection(i, ecd_dir);
-				}
+      // Set direction to LAS
+      m_IOBase->SetDirection(0, std::vector<double>{-1.0, 0.0, 0.0, 0.0}); // L
+      m_IOBase->SetDirection(1, std::vector<double>{0.0, 1.0, 0.0, 0.0});  // A
+      m_IOBase->SetDirection(2, std::vector<double>{0.0, 0.0, -1.0, 0.0}); // S
 			m_IOBase->SetDirection(3, std::vector<double>{0.0, 0.0, 0.0, 1.0});
 
 			std::vector<itk::ImageIOBase::SizeType> ecd_dim(4);

--- a/Logic/ImageWrapper/WrapperBase.h
+++ b/Logic/ImageWrapper/WrapperBase.h
@@ -85,6 +85,13 @@ public:
    */
   virtual itk::Object* GetUserData(const std::string &role) const;
 
+
+  virtual void RemoveUserData(const std::string &role)
+  {
+    if (m_UserDataMap.count(role))
+      m_UserDataMap.erase(role);
+  }
+
   /**
     Compute the image histogram. The histogram is cached inside of the
     object, so repeated calls to this function with the same nBins parameter


### PR DESCRIPTION
- Now correctly reorienting Cartesian DICOM from LPI to LAS instead of LPS
- Fixed an issue caused seg fault when closing overlay layer with volume rendering turned on