### PR TITLE
Fixed an issue caused dicom series reading error and an layer inspector error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,11 +91,11 @@ ENDIF()
 SET(SNAP_VERSION_MAJOR 4)
 SET(SNAP_VERSION_MINOR 0)
 SET(SNAP_VERSION_PATCH 0)
-SET(SNAP_VERSION_QUALIFIER "-rc.1")
+SET(SNAP_VERSION_QUALIFIER "-rc.2")
 
 # These fields should also be modified each time
-SET(SNAP_VERSION_RELEASE_DATE "20230120")
-SET(SNAP_VERSION_RELEASE_DATE_FORMATTED "January 20, 2023")
+SET(SNAP_VERSION_RELEASE_DATE "20230215")
+SET(SNAP_VERSION_RELEASE_DATE_FORMATTED "February 15, 2023")
 
 # This field should only change when the format of the settings files changes
 # in a non backwards-compatible way

--- a/GUI/Qt/Components/LayerInspectorRowDelegate.cxx
+++ b/GUI/Qt/Components/LayerInspectorRowDelegate.cxx
@@ -183,6 +183,7 @@ void LayerInspectorRowDelegate::SetModel(AbstractLayerTableRowModel *model)
   activateOnFlag(m_VolumeRenderingMenu, model, AbstractLayerTableRowModel::UIF_VOLUME_RENDERABLE, opt_hide);
   activateOnFlag(m_PopupMenu->findChild<QMenu*>("menuProcess"), model, AbstractLayerTableRowModel::UIF_IMAGE, opt_hide);
   activateOnFlag(m_OverlaysMenu, model, AbstractLayerTableRowModel::UIF_IMAGE, opt_hide);
+  activateOnFlag(ui->actionTextureFeatures, model, AbstractLayerTableRowModel::UIF_VOLUME_RENDERABLE);
 
   // Hook up the colormap and the slider's style sheet
   connectITK(m_Model->GetLayer(), WrapperChangeEvent());

--- a/Logic/ImageWrapper/IncreaseDimensionImageFilter.h
+++ b/Logic/ImageWrapper/IncreaseDimensionImageFilter.h
@@ -28,15 +28,19 @@ public:
   itkNewMacro(Self)
   itkStaticConstMacro(ImageDimension, unsigned int, InputImageType::ImageDimension);
 
+protected:
+
+  IncreaseDimensionImageFilter();
+  virtual ~IncreaseDimensionImageFilter() {};
+
   /**
    * Generate the data - by selecting an input and presenting it as output
    */
   void GenerateData() ITK_OVERRIDE;
 
-protected:
+  void GenerateOutputInformation() ITK_OVERRIDE;
 
-  IncreaseDimensionImageFilter();
-  virtual ~IncreaseDimensionImageFilter() {};
+
 };
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Logic/ImageWrapper/IncreaseDimensionImageFilter.txx
+++ b/Logic/ImageWrapper/IncreaseDimensionImageFilter.txx
@@ -14,6 +14,22 @@ void
 IncreaseDimensionImageFilter<TInputImage, TOutputImage>
 ::GenerateData()
 {
+  // Just pass the container to the output image
+  InputImageType *inputPtr = const_cast<InputImageType *>(this->GetInput());
+  OutputImageType *outputPtr = this->GetOutput();
+  outputPtr->SetPixelContainer(inputPtr->GetPixelContainer());
+}
+
+template <class TInputImage, class TOutputImage>
+void
+IncreaseDimensionImageFilter<TInputImage, TOutputImage>
+::GenerateOutputInformation()
+{
+  // From itk::TiledImageFilter, which does similar thing as this filter
+  // "Do not call the superclass's GenerateOutptuInformation method.
+  //  The input images are likely a different dimension than the input,
+  //  so the superclass's implementation is not compatible."
+
   unsigned int n_in = InputImageType::ImageDimension;
   unsigned int n_out = OutputImageType::ImageDimension;
 
@@ -45,8 +61,8 @@ IncreaseDimensionImageFilter<TInputImage, TOutputImage>
     {
     origin[i] = inputPtr->GetOrigin()[i];
     spacing[i] = inputPtr->GetSpacing()[i];
-    index[i] = inputPtr->GetBufferedRegion().GetIndex()[i];
-    size[i] = inputPtr->GetBufferedRegion().GetSize()[i];
+    index[i] = inputPtr->GetLargestPossibleRegion().GetIndex()[i];
+    size[i] = inputPtr->GetLargestPossibleRegion().GetSize()[i];
     for(unsigned int j = 0; j < n_in; j++)
       direction(i,j) = inputPtr->GetDirection()(i,j);
     }
@@ -56,8 +72,9 @@ IncreaseDimensionImageFilter<TInputImage, TOutputImage>
   outputPtr->SetOrigin(origin);
   outputPtr->SetSpacing(spacing);
   outputPtr->SetDirection(direction);
+  outputPtr->SetLargestPossibleRegion(region);
+  outputPtr->SetRequestedRegionToLargestPossibleRegion();
   outputPtr->SetBufferedRegion(region);
-  outputPtr->SetPixelContainer(inputPtr->GetPixelContainer());
 }
 
 

--- a/Logic/ImageWrapper/IncreaseDimensionImageFilter.txx
+++ b/Logic/ImageWrapper/IncreaseDimensionImageFilter.txx
@@ -74,6 +74,7 @@ IncreaseDimensionImageFilter<TInputImage, TOutputImage>
   outputPtr->SetDirection(direction);
   outputPtr->SetLargestPossibleRegion(region);
   outputPtr->SetRequestedRegionToLargestPossibleRegion();
+  outputPtr->SetNumberOfComponentsPerPixel(inputPtr->GetNumberOfComponentsPerPixel());
   outputPtr->SetBufferedRegion(region);
 }
 


### PR DESCRIPTION
The parent ITK filter of the IncreasedDimensionImageFilter failed to generate Output Information because lower dim cannot be dynamic_casted to higher dim. Based on itk::TileImageFilter, we need to override GenerateOutputInformation to make it work.

This will fix #81 , also mentioned by users in some user group threads.