### PR TITLE
3 Bug fixes for 4.0.1

### DIFF
--- a/Common/ExtendedGDCMSerieHelper.cxx
+++ b/Common/ExtendedGDCMSerieHelper.cxx
@@ -157,6 +157,7 @@ ExtendedGDCMSerieHelper
     {
     gdcmWarningMacro("Looks like all images have the exact same image position"
       << ". No PositionPatientOrdering sort performed" );
+    n_images_per_ipp = fileList->size(); // all files will be read into components for the same IPP
     return false;
     }
 

--- a/Common/Registry.h
+++ b/Common/Registry.h
@@ -563,6 +563,20 @@ public:
     SyntaxException(const char *text) : StringType(text) {}
   };
 
+  /** quick method check if a file is an XML file */
+  static bool IsXML(const char *name)
+  {
+    std::ifstream file(name);
+    if (file) {
+      std::string line;
+      std::getline(file, line);
+      if (line.find("<?xml") != std::string::npos) {
+          return true;
+      }
+    }
+    return false;
+  }
+
 private:
 
   // Hashtable type definition

--- a/GUI/Model/GlobalUIModel.cxx
+++ b/GUI/Model/GlobalUIModel.cxx
@@ -988,9 +988,9 @@ void GlobalUIModel::IncrementDrawingColorLabel(int delta)
   LabelType current = m_Driver->GetGlobalState()->GetDrawingColorLabel();
   ColorLabelTable::ValidLabelConstIterator pos =
       clt->GetValidLabels().find(current);
-  if(delta == 1)
+  if(delta == 1 && pos != clt->GetValidLabels().end())
     ++pos;
-  else if(delta == -1)
+  else if(delta == -1 && pos != clt->GetValidLabels().begin())
     --pos;
 
   if(pos != clt->GetValidLabels().end())

--- a/Logic/Framework/IRISApplication.cxx
+++ b/Logic/Framework/IRISApplication.cxx
@@ -2352,6 +2352,10 @@ bool IRISApplication::IsProjectFile(const char *filename)
   // This is pretty weak. What we really need is XML validation to check
   // that this is a real registry, and then some minimal check to see that
   // this is a project file
+
+  if (!Registry::IsXML(filename))
+    return false;
+
   try
   {
   Registry preg;


### PR DESCRIPTION
- Fixed an issue reporting invalid vector error when reading dicom series containing multiple images for only one slice
- Fixed an issue caused long reading time when drag&drop large image files
- Fixed an issue caused crash when using hotkeys `<` and `>` to change foreground labels