### PR TITLE
Bug fixes for 4.2.0-alpha.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,11 +94,11 @@ ENDIF()
 SET(SNAP_VERSION_MAJOR 4)
 SET(SNAP_VERSION_MINOR 2)
 SET(SNAP_VERSION_PATCH 0)
-SET(SNAP_VERSION_QUALIFIER "-alpha.1")
+SET(SNAP_VERSION_QUALIFIER "-alpha.2")
 
 # These fields should also be modified each time
-SET(SNAP_VERSION_RELEASE_DATE "20231204")
-SET(SNAP_VERSION_RELEASE_DATE_FORMATTED "December 4, 2023")
+SET(SNAP_VERSION_RELEASE_DATE "20240108")
+SET(SNAP_VERSION_RELEASE_DATE_FORMATTED "January 8, 2024")
 
 # This field should only change when the format of the settings files changes
 # in a non backwards-compatible way

--- a/Logic/ImageWrapper/GuidedNativeImageIO.cxx
+++ b/Logic/ImageWrapper/GuidedNativeImageIO.cxx
@@ -1705,7 +1705,10 @@ RescaleNativeImageToIntegralType<TOutputImage>
     {
     // We must compute the range of the input data    
     OutputComponentType omax = itk::NumericTraits<OutputComponentType>::max();
-    OutputComponentType omin = itk::NumericTraits<OutputComponentType>::min();
+    // -- we need to use lowest() instead of min(), because for double/float, min()
+    // -- only returns the smallest positive value a type can represent
+    // -- here we want to know the range including the negative values
+    OutputComponentType omin = itk::NumericTraits<OutputComponentType>::lowest();
 
     // Scan over all the image components. Avoid using iterators here because of
     // unnecessary overhead for vector images.

--- a/Logic/Slicing/ColorLookupTable.cxx
+++ b/Logic/Slicing/ColorLookupTable.cxx
@@ -10,7 +10,8 @@ void ColorLookupTable<TInputPixel, TDisplayPixel>
     m_LUT.resize(1 + FLOAT_LUT_MAX);
     m_StartValue = (TInputPixel) (t0 * (image_max - image_min) + image_min);
     m_EndValue = (TInputPixel) (t1 * (image_max - image_min) + image_min);
-    m_IntensityToLUTIndexScaleFactor = FLOAT_LUT_MAX / (m_EndValue - m_StartValue);
+    m_IntensityToLUTIndexScaleFactor = (m_EndValue == m_StartValue) ?
+                                       1.0 : FLOAT_LUT_MAX / (m_EndValue - m_StartValue);
     m_LUTIndexToCurveDomainScale = (t1 - t0) / FLOAT_LUT_MAX;
     m_LUTIndexToCurveDomainShift = t0;
   }
@@ -20,7 +21,7 @@ void ColorLookupTable<TInputPixel, TDisplayPixel>
     m_StartValue = image_min;
     m_EndValue = image_max;
     m_IntensityToLUTIndexScaleFactor = 1.0;
-    m_LUTIndexToCurveDomainScale = 1.0 / (image_max - image_min);
+    m_LUTIndexToCurveDomainScale = (image_max == image_min) ? 1.0 : 1.0 / (image_max - image_min);
     m_LUTIndexToCurveDomainShift = 0;
   }
 }

--- a/Logic/Slicing/IntensityToColorLookupTableImageFilter.h
+++ b/Logic/Slicing/IntensityToColorLookupTableImageFilter.h
@@ -94,8 +94,12 @@ public:
   using Superclass = itk::ImageToImageFilter<TInputImage,TInputImage>;
   using Pointer = SmartPtr<Self>;
   using ConstPointer = SmartPtr<const Self>;
-  using DataObjectPointer = itk::ProcessObject::DataObjectPointer;
-  using DataObjectIdentifierType = itk::ProcessObject::DataObjectIdentifierType;
+
+  // This is necessary to use itkGet/SetInputMacros to avoid gcc compiling error
+  using ProcessObject = itk::ProcessObject;
+
+  using DataObjectPointer = ProcessObject::DataObjectPointer;
+  using DataObjectIdentifierType = ProcessObject::DataObjectIdentifierType;
 
   // All the stuff from the input image
   using ImageType = TInputImage;

--- a/Logic/Slicing/LookupTableIntensityMappingFilter.h
+++ b/Logic/Slicing/LookupTableIntensityMappingFilter.h
@@ -38,6 +38,9 @@ public:
   // Output LUT
   using LookupTableType = ColorLookupTable<InputComponentType, OutputPixelType>;
 
+  // This is necessary to use itkGet/SetInputMacros to avoid gcc compiling error
+  using ProcessObject = itk::ProcessObject;
+
   itkTypeMacro(LookupTableIntensityMappingFilter, ImageToImageFilter)
   itkNewMacro(Self)
 

--- a/Logic/Slicing/RGBALookupTableIntensityMappingFilter.h
+++ b/Logic/Slicing/RGBALookupTableIntensityMappingFilter.h
@@ -35,6 +35,9 @@ public:
   typedef ColorLookupTable<InputPixelType, OutputComponentType> LookupTableType;
   typedef typename Superclass::OutputImageRegionType    OutputImageRegionType;
 
+  // This is necessary to use itkGet/SetInputMacros to avoid gcc compiling error
+  using ProcessObject = itk::ProcessObject;
+
   itkTypeMacro(RGBALookupTableIntensityMappingFilter, ImageToImageFilter)
   itkNewMacro(Self)
 


### PR DESCRIPTION
- Fixed namespace issue caused gcc compiling error
- Fixed a divide-by-zero error when reading real images filled with only one value
- Fixed an issue caused incorrect type casting for double images