### PR TITLE
Clarify how multiple files can be loaded

### DIFF
--- a/GUI/Qt/main.cxx
+++ b/GUI/Qt/main.cxx
@@ -143,10 +143,10 @@ void usage(const char *progname)
   cout << "Image Options:" << endl;
   cout << "   -g FILE              : Load the main image from FILE" << endl;
   cout << "   -s FILE [FILE+]      : Load the segmentation image from FILE" << endl;
-  cout << "                        :   (multiple files may be provided)" << endl;
+  cout << "                        :   (multiple space separated files may be provided)" << endl;
   cout << "   -l FILE              : Load label descriptions from FILE" << endl;
   cout << "   -o FILE [FILE+]      : Load additional images from FILE" << endl;
-  cout << "                        :   (multiple files may be provided)" << endl;
+  cout << "                        :   (multiple space separated files may be provided)" << endl;
   cout << "   -w FILE              : Load workspace from FILE" << endl;
   cout << "                        :   (-w cannot be mixed with -g,-s,-l,-o options)" << endl;
   cout << "Additional Options:" << endl;


### PR DESCRIPTION
I have been looking for this for a while and thought that it didn't work, but turns out I should just use space separation. This problem seemed to be relevant for quite some people online as well. I thought this would be nice to have in the --help.