### PR TITLE
Fixed time point update not changing mesh slicing rendering

### DIFF
--- a/GUI/Renderer/GenericSliceRenderer.cxx
+++ b/GUI/Renderer/GenericSliceRenderer.cxx
@@ -332,9 +332,11 @@ GenericSliceRenderer::RenderMeshes(AbstractRenderContext *context)
   auto         index = DisplaySliceIndex(m_Model->GetId(), DISPLAY_SLICE_MAIN);
   auto        *main_image = m_Model->GetDriver()->GetMainImage();
 
-  // Get the key to access the stored path from the layer
+  // Get the key to access the stored path from the layer.
+  // Include the timepoint in the key so each tp gets its own cached contour,
+  // and switching back to a previous tp correctly reuses that tp's cached contour.
   static const char *key_path[] = { "MeshSliceViewPath_0", "MeshSliceViewPath_1", "MeshSliceViewPath_2" };
-  auto layer_key = key_path[m_Model->GetId()];
+  std::string layer_key = std::string(key_path[m_Model->GetId()]) + "_tp" + std::to_string(tp);
 
   SNAPAppearanceSettings *as = m_Model->GetParentUI()->GetAppearanceSettings();
   const auto             &eltMesh = as->GetUIElement(SNAPAppearanceSettings::MESH_OUTLINE);


### PR DESCRIPTION
What was wrong: layer_key was "MeshSliceViewPath_0" (just the slice index). The mtime guard compares the stored contour's mtime against the mesh data's mtime — but when you switch timepoints, the new tp's mesh was loaded before the contour was last rendered for the old tp, so stored_contour->GetMTime() > mesh->GetMTime() and the cache falsely appears up-to-date.

The fix: Encode tp into the key ("MeshSliceViewPath_0_tp3", etc.). Now when tp changes, GetUserData returns null → cache miss → contour is recomputed for the correct timepoint. Switching back to a previous tp reuses its cached contour, so it also serves as a per-timepoint cache.