### PR TITLE
Support non-ASCII characters in Windows user names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1277,6 +1277,13 @@ IF(WIN32)
   # Add the .rc file
   SET(SNAP_MAIN_SRC ${SNAP_MAIN_SRC} ${SNAP_SOURCE_DIR}/Utilities/Win32/itksnap.rc)
 
+  # Application manifest, which requests the UTF-8 process code page needed for paths
+  # with non-ASCII characters. MSVC passes .manifest sources to the linker.
+  IF(MSVC)
+    SET(SNAP_WIN32_MANIFEST ${SNAP_SOURCE_DIR}/Utilities/Win32/itksnap.manifest)
+    SET(SNAP_MAIN_SRC ${SNAP_MAIN_SRC} ${SNAP_WIN32_MANIFEST})
+  ENDIF(MSVC)
+
 ENDIF(WIN32)
 
 
@@ -1423,6 +1430,14 @@ TARGET_LINK_LIBRARIES(logic_api_test ${SNAP_EXTERNAL_LIBS} itksnaplogic)
 TARGET_INCLUDE_DIRECTORIES(logic_api_test PUBLIC ${SNAP_INCLUDE_DIRS})
 
 add_test(NAME IRISApplicationTest COMMAND logic_api_test)
+
+# Needs the same manifest as the main executable to get the UTF-8 process code page
+ADD_EXECUTABLE(nonascii_path_test
+    Testing/Logic/NonAsciiPathTest.cxx ${SNAP_WIN32_MANIFEST})
+TARGET_LINK_LIBRARIES(nonascii_path_test ${SNAP_EXTERNAL_LIBS} itksnaplogic)
+TARGET_INCLUDE_DIRECTORIES(nonascii_path_test PUBLIC ${SNAP_INCLUDE_DIRS})
+
+add_test(NAME NonAsciiPathTest COMMAND nonascii_path_test ${TEMP})
 
 ADD_EXECUTABLE(remote_image_load_test
     Testing/Logic/RemoteImageLoadTest.cxx)

--- a/Common/SystemInterface.cxx
+++ b/Common/SystemInterface.cxx
@@ -102,16 +102,16 @@ SystemInterface::GetApplicationDataDirectory()
   // On failure due to a small buffer, the return value is the required size, not the
   // number of characters copied, and path_w has not been filled in.
   if (n_chars >= path_w_size)
-    throw IRISException("The APPDATA path on WIN32 is too long (%d characters).", (int) n_chars);
+    throw IRISException("The APPDATA path on WIN32 is too long (%d characters).", (int)n_chars);
 
   // Convert to UTF-8. Passing the length explicitly keeps the terminating null out of
   // the resulting std::string.
-  int size_needed = WideCharToMultiByte(CP_UTF8, 0, path_w, (int) n_chars, NULL, 0, NULL, NULL);
+  int size_needed = WideCharToMultiByte(CP_UTF8, 0, path_w, (int)n_chars, NULL, 0, NULL, NULL);
   if (size_needed <= 0)
     throw IRISException("Can not convert the APPDATA path to a UTF-8 string");
 
   std::string utf8_path(size_needed, 0);
-  WideCharToMultiByte(CP_UTF8, 0, path_w, (int) n_chars, &utf8_path[0], size_needed, NULL, NULL);
+  WideCharToMultiByte(CP_UTF8, 0, path_w, (int)n_chars, &utf8_path[0], size_needed, NULL, NULL);
 
   // Append the full information
   std::string strPath = utf8_path + "/itksnap.org/ITK-SNAP";

--- a/Common/SystemInterface.cxx
+++ b/Common/SystemInterface.cxx
@@ -90,23 +90,28 @@ SystemInfoDelegate *SystemInterface::m_SystemInfoDelegate = NULL;
 std::string
 SystemInterface::GetApplicationDataDirectory()
 {
-  // TODO: when the username is not ASCII, this crashes!
-  wchar_t path_w[4096];
-  DWORD bufferSize = GetEnvironmentVariableW(L"APPDATA", path_w, 4096);
-  if (!bufferSize)
+  // Read APPDATA as UTF-16 and convert it to UTF-8, the encoding ITK-SNAP uses for all
+  // std::string paths. Non-ASCII characters are supported because the application
+  // manifest (Utilities/Win32/itksnap.manifest) sets the process code page to UTF-8.
+  const DWORD path_w_size = 4096;
+  wchar_t     path_w[path_w_size];
+  DWORD       n_chars = GetEnvironmentVariableW(L"APPDATA", path_w, path_w_size);
+  if (n_chars == 0)
     throw IRISException("Can not access APPDATA path on WIN32.");
 
-  // Convert to multi-byte
-  int size_needed = WideCharToMultiByte(CP_UTF8, 0, &path_w[0], wcslen(path_w), NULL, 0, NULL, NULL);
+  // On failure due to a small buffer, the return value is the required size, not the
+  // number of characters copied, and path_w has not been filled in.
+  if (n_chars >= path_w_size)
+    throw IRISException("The APPDATA path on WIN32 is too long (%d characters).", (int) n_chars);
+
+  // Convert to UTF-8. Passing the length explicitly keeps the terminating null out of
+  // the resulting std::string.
+  int size_needed = WideCharToMultiByte(CP_UTF8, 0, path_w, (int) n_chars, NULL, 0, NULL, NULL);
+  if (size_needed <= 0)
+    throw IRISException("Can not convert the APPDATA path to a UTF-8 string");
+
   std::string utf8_path(size_needed, 0);
-  WideCharToMultiByte                  (CP_UTF8, 0, &path_w[0], wcslen(path_w), &utf8_path[0], size_needed, NULL, NULL);
-
-  if(utf8_path.length() == 0)
-    throw IRISException("Can not convert APPDATA path to multi-byte string");
-
-  // Temporary crap-out
-  if(utf8_path.length() != wcslen(path_w))
-    throw IRISException("ITK-SNAP currently does not support non-ASCII characters in user names on Windows (tm) platforms. This will be fixed in the future.");
+  WideCharToMultiByte(CP_UTF8, 0, path_w, (int) n_chars, &utf8_path[0], size_needed, NULL, NULL);
 
   // Append the full information
   std::string strPath = utf8_path + "/itksnap.org/ITK-SNAP";

--- a/Testing/Logic/NonAsciiPathTest.cxx
+++ b/Testing/Logic/NonAsciiPathTest.cxx
@@ -31,12 +31,12 @@ bool
 ExistsAccordingToNativeAPI(const std::string &utf8_path)
 {
 #ifdef WIN32
-  int n_wchars = MultiByteToWideChar(CP_UTF8, 0, utf8_path.c_str(), (int) utf8_path.length(), NULL, 0);
+  int n_wchars = MultiByteToWideChar(CP_UTF8, 0, utf8_path.c_str(), (int)utf8_path.length(), NULL, 0);
   if (n_wchars <= 0)
     return false;
 
   std::wstring wide_path(n_wchars, 0);
-  MultiByteToWideChar(CP_UTF8, 0, utf8_path.c_str(), (int) utf8_path.length(), &wide_path[0], n_wchars);
+  MultiByteToWideChar(CP_UTF8, 0, utf8_path.c_str(), (int)utf8_path.length(), &wide_path[0], n_wchars);
 
   return GetFileAttributesW(wide_path.c_str()) != INVALID_FILE_ATTRIBUTES;
 #else

--- a/Testing/Logic/NonAsciiPathTest.cxx
+++ b/Testing/Logic/NonAsciiPathTest.cxx
@@ -1,0 +1,154 @@
+/**
+ * Test directory creation and Registry IO on paths containing non-ASCII characters.
+ *
+ * On Windows this depends on the UTF-8 process code page requested by
+ * Utilities/Win32/itksnap.manifest. The test works inside its own temporary directory,
+ * so it is meaningful regardless of the user name of the account running it.
+ */
+
+#include "Registry.h"
+#include <itksys/SystemTools.hxx>
+#include <iostream>
+#include <string>
+
+#ifdef WIN32
+#  include <windows.h>
+#else
+#  include <sys/stat.h>
+#endif
+
+// U+00FC and U+65E5 U+672C, as explicit UTF-8 bytes so that the test does not depend on
+// the encoding the compiler assumes for this source file.
+static const char *UTF8_UMLAUT = "\xC3\xBC";
+static const char *UTF8_NIHON = "\xE6\x97\xA5\xE6\x9C\xAC";
+
+/**
+ * Check that a path exists without going through itksys or the narrow API, so that this
+ * answers "does a file with exactly this Unicode name exist" rather than "does a file
+ * whose name is these bytes in some code page exist".
+ */
+bool
+ExistsAccordingToNativeAPI(const std::string &utf8_path)
+{
+#ifdef WIN32
+  int n_wchars = MultiByteToWideChar(CP_UTF8, 0, utf8_path.c_str(), (int) utf8_path.length(), NULL, 0);
+  if (n_wchars <= 0)
+    return false;
+
+  std::wstring wide_path(n_wchars, 0);
+  MultiByteToWideChar(CP_UTF8, 0, utf8_path.c_str(), (int) utf8_path.length(), &wide_path[0], n_wchars);
+
+  return GetFileAttributesW(wide_path.c_str()) != INVALID_FILE_ATTRIBUTES;
+#else
+  struct stat buf;
+  return stat(utf8_path.c_str(), &buf) == 0;
+#endif
+}
+
+bool
+Check(bool condition, const char *description)
+{
+  std::cout << (condition ? "PASSED: " : "FAILED: ") << description << std::endl;
+  return condition;
+}
+
+int
+main(int argc, char *argv[])
+{
+  if (argc < 2)
+  {
+    std::cerr << "usage: nonascii_path_test <temp_dir>" << std::endl;
+    return 1;
+  }
+
+  // Build a directory name containing non-ASCII characters inside the temp directory
+  std::string base_dir = argv[1];
+  itksys::SystemTools::ConvertToUnixSlashes(base_dir);
+  std::string test_dir = base_dir + "/nonascii_M" + UTF8_UMLAUT + "ller_" + UTF8_NIHON;
+
+  // ... and a file with a non-ASCII name inside of it
+  std::string test_file = test_dir + "/Pr" + UTF8_UMLAUT + "ferenzen.xml";
+
+  // A value with non-ASCII characters, standing in for a label name
+  std::string test_value = std::string("Gr") + UTF8_UMLAUT + "n " + UTF8_NIHON;
+
+  std::cout << "Test directory (UTF-8): " << test_dir << std::endl;
+
+  bool ok = true;
+
+  // The cast is needed because MakeDirectory returns kwsys::Status, whose operator bool
+  // is explicit.
+  ok &= Check(static_cast<bool>(itksys::SystemTools::MakeDirectory(test_dir.c_str())),
+              "itksys::SystemTools::MakeDirectory reports success");
+
+  ok &= Check(itksys::SystemTools::FileIsDirectory(test_dir.c_str()),
+              "itksys::SystemTools::FileIsDirectory finds the directory");
+
+  // The key check: a legacy code page still creates a directory, just a mis-named one.
+  ok &= Check(ExistsAccordingToNativeAPI(test_dir),
+              "the directory exists under its intended Unicode name");
+
+  // Registry writes through the CRT rather than itksys, exercising the other path
+  Registry reg_out;
+  reg_out["TestEntry"] << test_value;
+  reg_out["Nested.Folder.Entry"] << 42;
+
+  bool write_ok = true;
+  try
+  {
+    reg_out.WriteToXMLFile(test_file.c_str());
+  }
+  catch (std::exception &exc)
+  {
+    std::cout << "  exception while writing: " << exc.what() << std::endl;
+    write_ok = false;
+  }
+  catch (...)
+  {
+    // Registry::IOException derives from std::string, not std::exception
+    std::cout << "  non-standard exception while writing" << std::endl;
+    write_ok = false;
+  }
+  ok &= Check(write_ok, "Registry::WriteToXMLFile writes to a non-ASCII path");
+
+  ok &= Check(ExistsAccordingToNativeAPI(test_file),
+              "the preference file exists under its intended Unicode name");
+
+  ok &= Check(itksys::SystemTools::FileExists(test_file.c_str(), true),
+              "itksys::SystemTools::FileExists finds the preference file");
+
+  // Read it back and make sure both the path and the non-ASCII content round-tripped
+  bool     read_ok = true;
+  Registry reg_in;
+  try
+  {
+    reg_in.ReadFromXMLFile(test_file.c_str());
+  }
+  catch (std::exception &exc)
+  {
+    std::cout << "  exception while reading: " << exc.what() << std::endl;
+    read_ok = false;
+  }
+  catch (...)
+  {
+    // Registry::IOException derives from std::string, not std::exception
+    std::cout << "  non-standard exception while reading" << std::endl;
+    read_ok = false;
+  }
+  ok &= Check(read_ok, "Registry::ReadFromXMLFile reads from a non-ASCII path");
+
+  if (read_ok)
+  {
+    ok &= Check(reg_in["TestEntry"][std::string()] == test_value,
+                "a non-ASCII registry value round-trips unchanged");
+    // -1 as the default: a literal 0 would be ambiguous between the int and
+    // const char * overloads of RegistryValue::operator[]
+    ok &= Check(reg_in["Nested.Folder.Entry"][-1] == 42, "a nested registry entry round-trips");
+  }
+
+  // Clean up, ignoring failures so that a cleanup problem does not mask the result
+  itksys::SystemTools::RemoveADirectory(test_dir.c_str());
+
+  std::cout << (ok ? "All checks passed." : "One or more checks FAILED.") << std::endl;
+  return ok ? 0 : 1;
+}

--- a/Utilities/Win32/itksnap.manifest
+++ b/Utilities/Win32/itksnap.manifest
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <!--
+    Sets the process code page to UTF-8 (Windows 10 1903+), so that itksys and the narrow
+    Win32 API decode ITK-SNAP's UTF-8 paths correctly. Without it, non-ASCII characters in
+    %APPDATA% are misdecoded. Keep this minimal: adding dpiAware or supportedOS entries
+    would override what Qt configures.
+  -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
ITK-SNAP refuses to start when the Windows user name contains non-ASCII characters ("_ITK-SNAP currently does not support non-ASCII characters in user names on Windows (tm) platforms_").

That guard comes from 2ad73dec (2014), added because *"current itksys does not support multi-byte encoding. This seems to be fixed in ITK 4.5, but not ready to switch yet"*. ITK-SNAP now requires ITK >= 5.4. It is also not a failure check: it compares the UTF-8 byte length of the APPDATA path against its wide-character length, which differ for any non-ASCII character.

**Removing it alone is not enough.** itksys converts narrow paths to wide with `MultiByteToWideChar(KWSYS_ENCODING_DEFAULT_CODEPAGE, ...)`, which ITK leaves at its `CP_ACP` default. Under a legacy code page `MakeDirectory()` does not fail on UTF-8 input; it silently creates a mis-named directory, so settings would end up somewhere wrong. (The CRT route used by `Registry` is already covered by the `setlocale(LC_ALL, ".UTF8")` from 2b9dda90.)

So this adds an application manifest requesting the UTF-8 process code page (Windows 10 1903+), making `CP_ACP` mean UTF-8 and lining both routes up without rebuilding ITK. It is deliberately minimal, with no `dpiAware` or `supportedOS` entries, and it is guarded by `IF(MSVC)`, so Linux and macOS are untouched. On Windows older than 1903 the setting is ignored and behaviour is unchanged. Two unchecked return values in the same function are fixed along the way.

**Testing** (MSVC 2022, Qt 6.8.1, ITK 5.4.0, VTK 9.5.2): the new `NonAsciiPathTest` covers directory creation and Registry IO on a non-ASCII path, checking the result with the wide Win32 API so that mojibake is detected instead of being reported as success. It uses its own temp directory, so it is meaningful on an ASCII-named CI account, and it passes. A packaged build launched with `%APPDATA%` pointing at a non-ASCII directory starts normally, while the same build from master refuses to. The roughly 5 other Windows test failures are pre-existing.

**Not covered:** the manifest is applied to `ITK-SNAP.exe` and the new test only. Glad to extend it to `itksnap-wt`, `c3d` and `greedy` if you want that in this PR. `GetApplicationDataDirectory()` also still reads `%APPDATA%` rather than using the Qt delegate as the macOS branch does, because `QStandardPaths` ignores that variable, which would remove the only practical way to test this without creating a non-ASCII Windows account.