### PR TITLE
Fix invalid orientation codes for oblique images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1424,6 +1424,17 @@ TARGET_INCLUDE_DIRECTORIES(logic_api_test PUBLIC ${SNAP_INCLUDE_DIRS})
 
 add_test(NAME IRISApplicationTest COMMAND logic_api_test)
 
+# Regression coverage for global anatomical-axis assignment of oblique images.
+ADD_EXECUTABLE(image_coordinate_geometry_test
+    Testing/Logic/ImageCoordinateGeometryTest.cxx)
+TARGET_LINK_LIBRARIES(image_coordinate_geometry_test
+    ${SNAP_EXTERNAL_LIBS} itksnaplogic)
+TARGET_INCLUDE_DIRECTORIES(image_coordinate_geometry_test PUBLIC
+    ${SNAP_INCLUDE_DIRS})
+
+add_test(NAME ImageCoordinateGeometryTest
+    COMMAND image_coordinate_geometry_test)
+
 ADD_EXECUTABLE(remote_image_load_test
     Testing/Logic/RemoteImageLoadTest.cxx)
 TARGET_LINK_LIBRARIES(remote_image_load_test ${SNAP_EXTERNAL_LIBS} itksnaplogic)

--- a/Logic/Common/ImageCoordinateGeometry.cxx
+++ b/Logic/Common/ImageCoordinateGeometry.cxx
@@ -35,6 +35,11 @@
 #include "ImageCoordinateGeometry.h"
 #include "IRISException.h"
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+
 const char ImageCoordinateGeometry::m_RAICodes[3][2] = {
   {'R', 'L'},
   {'A', 'P'},
@@ -229,29 +234,42 @@ ImageCoordinateGeometry
   const static std::string rai_start("RAI"), rai_end("LPS");
   std::string rai_out("...");
 
-  for(size_t i = 0; i < 3; i++)
+  // Find the globally closest one-to-one assignment between image axes
+  // (matrix columns) and anatomical axes (matrix rows). Selecting the
+  // largest entry in every column independently can assign the same
+  // anatomical axis more than once for strongly oblique images, producing
+  // invalid codes such as SAP, SAA, or IRI. For a direction cosine matrix,
+  // the signed cardinal matrix closest in Frobenius norm is obtained by
+  // choosing the row permutation that maximizes the sum of the selected
+  // absolute direction cosines. There are only 3! = 6 assignments.
+  std::array<size_t, 3> permutation = {{0, 1, 2}};
+  std::array<size_t, 3> best_permutation = permutation;
+  double best_score = -std::numeric_limits<double>::infinity();
+
+  do
     {
-    // Get the direction of the i-th voxel coordinate
-    vnl_vector<double> dir_i = mat.get_column(i);
-
-    // Get the maximum angle with any axis
-    double maxabs_i = dir_i.inf_norm();
-    for(size_t off = 0; off < 3; off++)
+    double score = 0.0;
+    for(size_t i = 0; i < 3; ++i)
       {
-      // This trick allows us to visit (i,i) first, so that if one of the
-      // direction cosines makes the same angle with two of the axes, we 
-      // can still assign a valid RAI code
-      size_t j = (i + off) % 3;
+      score += std::fabs(mat(permutation[i], i));
+      }
 
-      // Is j the best-matching direction?
-      if(fabs(dir_i[j]) == maxabs_i)
-        {
-        rai_out[i] = dir_i[j] > 0 ? rai_start[j] : rai_end[j];
-        break;
-        }
+    // Keep the first permutation on exact ties. Since permutations are
+    // visited lexicographically, an axis-aligned identity remains RAI.
+    if(score > best_score)
+      {
+      best_score = score;
+      best_permutation = permutation;
       }
     }
-      
+  while(std::next_permutation(permutation.begin(), permutation.end()));
+
+  for(size_t i = 0; i < 3; ++i)
+    {
+    const size_t j = best_permutation[i];
+    rai_out[i] = mat(j, i) > 0 ? rai_start[j] : rai_end[j];
+    }
+
   return rai_out;
 }
 

--- a/Testing/Logic/ImageCoordinateGeometryTest.cxx
+++ b/Testing/Logic/ImageCoordinateGeometryTest.cxx
@@ -80,14 +80,32 @@ int main()
   saa(2, 0) = -0.787153390; saa(2, 1) = -0.437837730; saa(2, 2) =  0.434381920;
   success = ExpectCode("oblique SAA regression", saa, "SRA") && success;
 
-  // Direction matrix reported in GitHub issue #69 for a clinical shoulder
-  // MRI. Independent column selection maps two columns to the left-right axis;
-  // the global assignment produces the valid closest code LSP.
-  DirectionMatrix issue_69(3, 3);
-  issue_69(0, 0) = -0.71844119; issue_69(0, 1) =  0.06575722; issue_69(0, 2) = -0.69247257;
-  issue_69(1, 0) =  0.67544218; issue_69(1, 1) =  0.30380508; issue_69(1, 2) = -0.67192283;
-  issue_69(2, 0) =  0.16619304; issue_69(2, 1) = -0.95046224; issue_69(2, 2) = -0.26268128;
-  success = ExpectCode("issue 69 oblique regression", issue_69, "LSP") && success;
+  // The original NIfTI affine from GitHub issue #69 is expressed in RAS
+  // coordinates. ITK converts NIfTI geometry to LPS by negating the first two
+  // rows before this function sees the direction matrix. The previous
+  // per-column argmax produced IRI; the global assignment recovers RAI.
+  DirectionMatrix issue_69_ras(3, 3);
+  issue_69_ras(0, 0) = -0.656692; issue_69_ras(0, 1) = -0.676962; issue_69_ras(0, 2) =  0.332383;
+  issue_69_ras(1, 0) =  0.360389; issue_69_ras(1, 1) = -0.668844; issue_69_ras(1, 2) = -0.650205;
+  issue_69_ras(2, 0) =  0.662477; issue_69_ras(2, 1) = -0.307197; issue_69_ras(2, 2) =  0.683194;
+
+  DirectionMatrix issue_69_lps = issue_69_ras;
+  for(size_t column = 0; column < 3; ++column)
+    {
+    issue_69_lps(0, column) *= -1.0;
+    issue_69_lps(1, column) *= -1.0;
+    }
+  success = ExpectCode("issue 69 IRI regression", issue_69_lps, "RAI") && success;
+
+  // A clinical shoulder MRI direction matrix posted in a later comment on
+  // issue #69. Independent column selection maps two columns to the left-right
+  // axis; the global assignment produces the valid closest code LSP.
+  DirectionMatrix shoulder(3, 3);
+  shoulder(0, 0) = -0.71844119; shoulder(0, 1) =  0.06575722; shoulder(0, 2) = -0.69247257;
+  shoulder(1, 0) =  0.67544218; shoulder(1, 1) =  0.30380508; shoulder(1, 2) = -0.67192283;
+  shoulder(2, 0) =  0.16619304; shoulder(2, 1) = -0.95046224; shoulder(2, 2) = -0.26268128;
+  success = ExpectCode("issue 69 shoulder MRI regression",
+                       shoulder, "LSP") && success;
 
   return success ? 0 : 1;
 }

--- a/Testing/Logic/ImageCoordinateGeometryTest.cxx
+++ b/Testing/Logic/ImageCoordinateGeometryTest.cxx
@@ -1,0 +1,93 @@
+#include "ImageCoordinateGeometry.h"
+
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <string>
+
+namespace
+{
+using DirectionMatrix = ImageCoordinateGeometry::DirectionMatrix;
+
+bool ExpectCode(const std::string &name,
+                const DirectionMatrix &matrix,
+                const std::string &expected)
+{
+  const std::string actual =
+    ImageCoordinateGeometry::ConvertDirectionMatrixToClosestRAICode(matrix);
+
+  if(actual != expected)
+    {
+    std::cerr << name << ": expected " << expected << ", got " << actual
+              << std::endl;
+    return false;
+    }
+
+  if(!ImageCoordinateGeometry::IsRAICodeValid(actual))
+    {
+    std::cerr << name << ": result is not a valid RAI code: " << actual
+              << std::endl;
+    return false;
+    }
+
+  return true;
+}
+}
+
+int main()
+{
+  bool success = true;
+
+  // Every signed cardinal orientation must round-trip exactly. This covers
+  // all 3! axis permutations and all 2^3 sign combinations (48 codes).
+  const std::string positive_letters("RAI");
+  const std::string negative_letters("LPS");
+  std::array<size_t, 3> permutation = {{0, 1, 2}};
+  do
+    {
+    for(unsigned int sign_bits = 0; sign_bits < 8; ++sign_bits)
+      {
+      std::string code("...");
+      for(size_t column = 0; column < 3; ++column)
+        {
+        const size_t row = permutation[column];
+        const bool positive = (sign_bits & (1u << column)) != 0;
+        code[column] = positive ? positive_letters[row] : negative_letters[row];
+        }
+
+      const DirectionMatrix cardinal =
+        ImageCoordinateGeometry::ConvertRAICodeToDirectionMatrix(code);
+      success = ExpectCode("cardinal " + code, cardinal, code) && success;
+      }
+    }
+  while(std::next_permutation(permutation.begin(), permutation.end()));
+
+  // Real oblique direction matrix that the previous per-column argmax
+  // converted to the invalid code SAP. The closest one-to-one assignment is
+  // SAR.
+  DirectionMatrix sap(3, 3);
+  sap(0, 0) = -0.562583101; sap(0, 1) =  0.530269256; sap(0, 2) =  0.634282828;
+  sap(1, 0) =  0.000000000; sap(1, 1) =  0.767208939; sap(1, 2) = -0.641397585;
+  sap(2, 0) = -0.826740742; sap(2, 1) = -0.360839245; sap(2, 2) = -0.431618387;
+  success = ExpectCode("oblique SAP regression", sap, "SAR") && success;
+
+  // Real oblique direction matrix that the previous implementation converted
+  // to SAA. A global assignment uses each anatomical axis exactly once and
+  // selects SRA.
+  DirectionMatrix saa(3, 3);
+  saa(0, 0) = -0.616757270; saa(0, 1) =  0.558802430; saa(0, 2) = -0.554391840;
+  saa(1, 0) =  0.000000010; saa(1, 1) =  0.704299630; saa(1, 2) =  0.709902840;
+  saa(2, 0) = -0.787153390; saa(2, 1) = -0.437837730; saa(2, 2) =  0.434381920;
+  success = ExpectCode("oblique SAA regression", saa, "SRA") && success;
+
+  // Direction matrix reported in GitHub issue #69 for a clinical shoulder
+  // MRI. Independent column selection maps two columns to the left-right axis;
+  // the global assignment produces the valid closest code LSP.
+  DirectionMatrix issue_69(3, 3);
+  issue_69(0, 0) = -0.71844119; issue_69(0, 1) =  0.06575722; issue_69(0, 2) = -0.69247257;
+  issue_69(1, 0) =  0.67544218; issue_69(1, 1) =  0.30380508; issue_69(1, 2) = -0.67192283;
+  issue_69(2, 0) =  0.16619304; issue_69(2, 1) = -0.95046224; issue_69(2, 2) = -0.26268128;
+  success = ExpectCode("issue 69 oblique regression", issue_69, "LSP") && success;
+
+  return success ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Replace independent per-column anatomical-axis selection with a global one-to-one assignment between image axes and anatomical axes.
- Prevent strongly oblique direction matrices from producing invalid orientation codes such as `SAP`, `SAA`, or `IRI`.
- Preserve exact round-trip behavior for all 48 signed cardinal orientation codes.
- Add regression coverage for two real-world oblique NIfTI matrices, the original affine from #69, and the clinical shoulder MRI matrix posted later in that issue.

## Root cause

`ConvertDirectionMatrixToClosestRAICode` previously selected the largest absolute direction cosine independently for each image axis. For strongly oblique images, two columns can select the same anatomical axis. The resulting three-letter code then repeats an anatomical axis and fails `IsRAICodeValid`, causing ITK-SNAP to reject an otherwise readable image.

## Approach

The updated implementation examines all `3! = 6` one-to-one assignments between image axes (matrix columns) and anatomical axes (matrix rows). It selects the assignment that maximizes the sum of the corresponding absolute direction cosines, then uses each selected cosine's sign to choose the RAI letter.

This is the signed cardinal matrix closest to the input direction matrix in Frobenius norm. It guarantees that each anatomical axis is used exactly once, with deterministic behavior on exact ties. The image direction matrix and physical geometry are not modified; only the closest valid orientation code is derived differently.

## User impact

Valid strongly oblique images that were previously rejected because their derived code repeated an anatomical axis can now be opened normally. Existing cardinal orientations retain their previous codes.

## Testing

The new `ImageCoordinateGeometryTest` covers:

- all 48 combinations of the 6 axis permutations and 8 sign combinations;
- a real matrix previously reported as invalid `SAP`, now assigned `SAR`;
- a real matrix previously reported as invalid `SAA`, now assigned `SRA`;
- the original NIfTI/RAS affine from #69, converted to the ITK/LPS direction matrix that previously produced `IRI` and is now assigned `RAI`;
- the clinical shoulder MRI direction matrix posted in a later #69 comment, assigned the valid closest code `LSP`.

The production source and test were rebuilt and the test executable passed locally on Apple Silicon macOS. Repository CI will provide the complete supported dependency and platform build coverage.

Fixes #69.
