### PR TITLE
DOC: Add contributing, governance, code of conduct, and developer guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -73,15 +73,15 @@ Conduct reinforces encouraged behaviors and norms that can help avoid conflicts 
 harm.
 
 When an incident does occur, it is important to report it promptly. To report a possible
-violation, email
-<!-- TODO(review): replace with the address that should receive Code of Conduct reports.
-     Options discussed: the lead maintainer's institutional address, or a shared alias such
-     as conduct@itksnap.org. This must be a monitored address before the file is merged.
-     Contributor Covenant 3.0 leaves this as a required placeholder. -->
-**CONDUCT-CONTACT-TBD**. Reports are received by the ITK-SNAP maintainers.
+violation, email either of the ITK-SNAP maintainers directly:
 
-If a report concerns a maintainer, you may address it to any other maintainer individually;
-that maintainer will not take part in deciding the response to a report about themselves.
+- Paul A. Yushkevich — <pauly2@pennmedicine.upenn.edu>
+- Jilei Hao — <jilei.hao@pennmedicine.upenn.edu>
+
+You may write to either one, and you do not need to explain your choice. Both addresses are
+listed separately, rather than as a single shared address, so that a report concerning one
+maintainer can be sent to the other: **a maintainer takes no part in investigating or
+deciding the response to a report about themselves.**
 
 Community Moderators take reports of violations seriously and will make every effort to
 respond in a timely manner. They will investigate all reports of code of conduct violations,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or
+invisible disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community
+include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and
+  learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without
+  their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional
+  setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in response to
+any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this
+Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an
+individual is officially representing the community in public spaces. Examples of
+representing our community include using an official email address, posting via an
+official social media account, or acting as an appointed representative at an online or
+offline event.
+
+For ITK-SNAP, community spaces include the GitHub repository (issues, pull requests, and
+discussions), the ITK-SNAP users' and developers' mailing lists, and ITK-SNAP training
+events and workshops.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to
+the community leaders responsible for enforcement at
+<!-- TODO(review): replace with the address that should receive Code of Conduct reports.
+     Options discussed: the lead maintainer's institutional address, or a shared alias
+     such as conduct@itksnap.org. This must be a monitored address before the file is
+     merged. -->
+**CONDUCT-CONTACT-TBD**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter
+of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the
+consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity
+around the nature of the violation and an explanation of why the behavior was
+inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with
+the people involved, including unsolicited interaction with those enforcing the Code of
+Conduct, for a specified period of time. This includes avoiding interactions in community
+spaces as well as external channels like social media. Violating these terms may lead to
+a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained
+inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication
+with the community for a specified period of time. No public or private interaction with
+the people involved, including unsolicited interaction with those enforcing the Code of
+Conduct, is allowed during this period. Violating these terms may lead to a permanent
+ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards,
+including sustained inappropriate behavior, harassment of an individual, or aggression
+toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,129 +1,166 @@
-# Contributor Covenant Code of Conduct
+# ITK-SNAP Code of Conduct
+
+This Code of Conduct applies to everyone participating in the ITK-SNAP community. It is
+adapted from [Contributor Covenant 3.0](https://www.contributor-covenant.org/version/3/0/).
+
+**Community Moderators.** Where this document refers to Community Moderators, it means the
+ITK-SNAP maintainers listed in [GOVERNANCE.md](GOVERNANCE.md).
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our community a
-harassment-free experience for everyone, regardless of age, body size, visible or
-invisible disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal appearance,
-race, caste, color, religion, or sexual identity and orientation.
+We pledge to make our community welcoming, safe, and equitable for all.
 
-We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
-inclusive, and healthy community.
+We are committed to fostering an environment that respects and promotes the dignity,
+rights, and contributions of all individuals, regardless of characteristics including race,
+ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or
+gender, gender identity or expression, sexual orientation, language, philosophy or religion,
+national or social origin, socio-economic position, level of education, or other status. The
+same privileges of participation are extended to everyone who participates in good faith and
+in accordance with this Covenant.
 
-## Our Standards
+## Encouraged Behaviors
 
-Examples of behavior that contributes to a positive environment for our community
-include:
+While acknowledging differences in social norms, we all strive to meet our community's
+expectations for positive behavior. We also understand that our words and actions may be
+interpreted differently than we intend based on culture, background, or native language.
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and
-  learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
+With these considerations in mind, we agree to behave mindfully toward each other and act in
+ways that center our shared values, including:
 
-Examples of unacceptable behavior include:
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
 
-* The use of sexualized language or imagery, and sexual attention or advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address, without
-  their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional
-  setting
+## Restricted Behaviors
 
-## Enforcement Responsibilities
+We agree to restrict the following behaviors in our community. Instances, threats, and
+promotion of these behaviors are violations of this Code of Conduct.
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in response to
-any behavior that they deem inappropriate, threatening, offensive, or harmful.
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary
+   personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a
+   community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on
+   the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately
+   intimate in the context or purpose of the community.
+5. **Violating confidentiality.** Sharing or acting on someone's personal or private
+   information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any
+   person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
 
-Community leaders have the right and responsibility to remove, edit, or reject comments,
-commits, code, wiki edits, issues, and other contributions that are not aligned to this
-Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be
+   someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you
+   contribute.
+3. **Promotional materials.** Sharing marketing or other commercial content in a way that is
+   outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes,
+   links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to
+collaborate. Not every conflict represents a code of conduct violation, and this Code of
+Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize
+harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible
+violation, email
+<!-- TODO(review): replace with the address that should receive Code of Conduct reports.
+     Options discussed: the lead maintainer's institutional address, or a shared alias such
+     as conduct@itksnap.org. This must be a monitored address before the file is merged.
+     Contributor Covenant 3.0 leaves this as a required placeholder. -->
+**CONDUCT-CONTACT-TBD**. Reports are received by the ITK-SNAP maintainers.
+
+If a report concerns a maintainer, you may address it to any other maintainer individually;
+that maintainer will not take part in deciding the response to a report about themselves.
+
+Community Moderators take reports of violations seriously and will make every effort to
+respond in a timely manner. They will investigate all reports of code of conduct violations,
+reviewing messages, logs, and recordings, or interviewing witnesses and other participants.
+Community Moderators will keep investigation and enforcement actions as transparent as
+possible while prioritizing safety and confidentiality. In order to honor these values,
+enforcement actions are carried out in private with the involved parties, but communicating
+to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been
+violated, the following enforcement ladder may be used to determine how best to repair harm,
+based on the incident's impact on the individuals involved and the community as a whole.
+Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1. **Warning**
+   1. *Event:* A violation involving a single incident or series of incidents.
+   2. *Consequence:* A private, written warning from the Community Moderators.
+   3. *Repair:* Examples of repair include a private written apology, acknowledgement of
+      responsibility, and seeking clarification on expectations.
+2. **Temporarily Limited Activities**
+   1. *Event:* A repeated incidence of a violation that previously resulted in a warning, or
+      the first incidence of a more serious violation.
+   2. *Consequence:* A private, written warning with a time-limited cooldown period designed
+      to underscore the seriousness of the situation and give the community members involved
+      time to process the incident. The cooldown period may be limited to particular
+      communication channels or interactions with particular community members.
+   3. *Repair:* Examples of repair may include making an apology, using the cooldown period
+      to reflect on actions and impact, and being thoughtful about re-entering community
+      spaces after the period is over.
+3. **Temporary Suspension**
+   1. *Event:* A pattern of repeated violation which the Community Moderators have tried to
+      address with warnings, or a single serious violation.
+   2. *Consequence:* A private written warning with conditions for return from suspension.
+      In general, temporary suspensions give the person being suspended time to reflect upon
+      their behavior and possible corrective actions.
+   3. *Repair:* Examples of repair include respecting the spirit of the suspension, meeting
+      the specified conditions for return, and being thoughtful about how to reintegrate with
+      the community when the suspension is lifted.
+4. **Permanent Ban**
+   1. *Event:* A pattern of repeated code of conduct violations that other steps on the
+      ladder have failed to resolve, or a violation so serious that the Community Moderators
+      determine there is no way to keep the community safe with this person as a member.
+   2. *Consequence:* Access to all community spaces, tools, and communication channels is
+      removed. In general, permanent bans should be rarely used, should have strong reasoning
+      behind them, and should only be resorted to if working through other remedies has
+      failed to change the behavior.
+   3. *Repair:* There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of
+Community Moderators to use their discretion and judgment, in keeping with the best interests
+of our community.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an
-individual is officially representing the community in public spaces. Examples of
-representing our community include using an official email address, posting via an
-official social media account, or acting as an appointed representative at an online or
-offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual
+is officially representing the community in public or other spaces. Examples of representing
+our community include using an official email address, posting via an official social media
+account, or acting as an appointed representative at an online or offline event.
 
-For ITK-SNAP, community spaces include the GitHub repository (issues, pull requests, and
+For ITK-SNAP, community spaces include the GitHub repositories (issues, pull requests, and
 discussions), the ITK-SNAP users' and developers' mailing lists, and ITK-SNAP training
-events and workshops.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to
-the community leaders responsible for enforcement at
-<!-- TODO(review): replace with the address that should receive Code of Conduct reports.
-     Options discussed: the lead maintainer's institutional address, or a shared alias
-     such as conduct@itksnap.org. This must be a monitored address before the file is
-     merged. -->
-**CONDUCT-CONTACT-TBD**.
-All complaints will be reviewed and investigated promptly and fairly.
-
-All community leaders are obligated to respect the privacy and security of the reporter
-of any incident.
-
-## Enforcement Guidelines
-
-Community leaders will follow these Community Impact Guidelines in determining the
-consequences for any action they deem in violation of this Code of Conduct:
-
-### 1. Correction
-
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing clarity
-around the nature of the violation and an explanation of why the behavior was
-inappropriate. A public apology may be requested.
-
-### 2. Warning
-
-**Community Impact**: A violation through a single incident or series of actions.
-
-**Consequence**: A warning with consequences for continued behavior. No interaction with
-the people involved, including unsolicited interaction with those enforcing the Code of
-Conduct, for a specified period of time. This includes avoiding interactions in community
-spaces as well as external channels like social media. Violating these terms may lead to
-a temporary or permanent ban.
-
-### 3. Temporary Ban
-
-**Community Impact**: A serious violation of community standards, including sustained
-inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public communication
-with the community for a specified period of time. No public or private interaction with
-the people involved, including unsolicited interaction with those enforcing the Code of
-Conduct, is allowed during this period. Violating these terms may lead to a permanent
-ban.
-
-### 4. Permanent Ban
-
-**Community Impact**: Demonstrating a pattern of violation of community standards,
-including sustained inappropriate behavior, harassment of an individual, or aggression
-toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within the
-community.
+courses, workshops, and other project events.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
-available at
-https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently
+available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
 
-Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under
+CC BY-SA 4.0. To view a copy of this license, visit
+[https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
 
-[homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+For answers to common questions about Contributor Covenant, see the FAQ at
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).
+Translations are provided at
+[https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).
+Additional enforcement and community guideline resources can be found at
+[https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources).
+The enforcement ladder was inspired by the work of
+[Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,10 @@ ITK-SNAP uses a fork-and-pull-request model.
 3. **Make your changes**, keeping the branch focused on one thing. Unrelated cleanups
    in the same branch make review harder and are usually asked to be split out.
 
-4. **Build and test locally** before pushing (see the Developer Guide). At a minimum,
-   the project should build without new warnings on your platform and `ctest` should
-   show no new failures.
+4. **Build and test locally** before pushing, if you can (see the Developer Guide).
+   Checking that the project still builds on your platform and that `ctest` shows no new
+   failures will usually save a review round-trip — but CI checks this too, so a pull
+   request you could not fully test locally is still worth opening.
 
 5. **Push** to your fork and **open a pull request** against `master`.
 
@@ -71,8 +72,14 @@ ITK-SNAP uses a fork-and-pull-request model.
 
 ## Commit messages
 
-ITK-SNAP follows the commit-message convention used across the ITK/VTK/3D Slicer
-ecosystem. Prefix the subject line with the kind of change:
+**These are recommendations, not requirements.** The maintainers are adopting this
+convention themselves first, and will consider asking for it more firmly only once it has
+proven worth the friction in day-to-day use. A clear, honest commit message that follows
+none of the advice below is worth more than a well-formatted one that does not explain the
+change — please do not let formatting rules stop you from contributing.
+
+That said, the convention we are moving toward is the one used across the ITK/VTK/3D Slicer
+ecosystem: prefix the subject line with the kind of change.
 
 | Prefix   | Meaning                                                     |
 | -------- | ----------------------------------------------------------- |
@@ -84,7 +91,7 @@ ecosystem. Prefix the subject line with the kind of change:
 | `STYLE:` | Formatting or cosmetic change, no functional effect          |
 | `WIP:`   | Work in progress, not ready to merge                         |
 
-Guidelines:
+Suggestions that tend to help:
 
 - Keep the subject line under 72 characters and write it in the imperative mood
   ("Fix crash when closing a workspace", not "Fixed" or "Fixes").
@@ -104,19 +111,28 @@ Wait for the mesh worker to finish before tearing down the model.
 Fixes #456
 ```
 
-## What a pull request should contain
+## What makes a pull request easy to review
 
-- **A clear description** of the problem and the approach taken.
-- **Tests** for new functionality or for a bug fix, where the change is testable.
-  Test data lives in `Testing/TestData/`; GUI tests are driven by scripts under
-  `GUI/Qt/Resources/Scripts/`.
-- **No unrelated changes** — no reformatting of files you did not otherwise touch.
-- **Consistent formatting.** The repository has a `.clang-format` at its root; format
-  the lines you add or change. Please do not reformat whole existing files, as this
-  obscures history.
-- **Backward compatibility.** ITK-SNAP reads workspaces and images written by older
-  versions; changes to file formats, the workspace schema, or the command-line
-  interface need explicit discussion.
+These are recommendations rather than a checklist you must satisfy. They describe what
+tends to make a change quick to review and merge; none of them is a precondition for
+opening a pull request, and a maintainer can help with any of them during review.
+
+- **A clear description** of the problem and the approach taken. This is the one that
+  helps most, and it costs the least.
+- **Tests** for new functionality or for a bug fix, where the change is testable. Test data
+  lives in `Testing/TestData/`; GUI test scripts live in `Testing/GUI/Qt/Scripts/`. If you
+  are not sure how to test something, open the pull request anyway and ask.
+- **No unrelated changes** — keeping reformatting out of a functional change makes the
+  functional part visible.
+- **Consistent formatting.** The repository has a `.clang-format` at its root; formatting
+  the lines you add or change is helpful. Please avoid reformatting whole existing files,
+  which obscures history and makes the real change hard to find.
+- **Backward compatibility.** This is the one place we would genuinely rather hear from you
+  first. ITK-SNAP opens workspaces and images written by much older versions, and users
+  depend on that. If your change touches a file format, the workspace schema, or the
+  command-line interface, please raise it in an issue before investing much time — not
+  because the change is unwelcome, but because getting the compatibility story right early
+  is much easier than reworking it later.
 
 ## Continuous integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing to ITK-SNAP
+
+Thank you for your interest in improving ITK-SNAP. ITK-SNAP is developed openly on
+GitHub, and contributions of all kinds — bug reports, documentation, test cases, and
+code — are welcome.
+
+This document describes how to contribute. For who makes decisions and how the project
+is run, see [GOVERNANCE.md](GOVERNANCE.md). All participants are expected to follow our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+**Ask a question.** Usage questions are best asked on the
+[ITK-SNAP Users' mailing list](http://www.itksnap.org/pmwiki/pmwiki.php?n=MailingLists),
+not the issue tracker.
+
+**Report a bug.** Open an issue at
+<https://github.com/pyushkevich/itksnap/issues>. A good report includes:
+
+- the ITK-SNAP version (**Help → About**) and your operating system;
+- what you did, what you expected, and what happened instead;
+- a minimal image or workspace that reproduces the problem, if you can share one.
+
+**Suggest a feature.** Open an issue describing the problem you are trying to solve
+before writing code. ITK-SNAP is used by a broad community across many imaging domains,
+and a short discussion up front usually saves a lot of rework.
+
+**Improve documentation.** Corrections to the developer documentation under
+[`Documentation/Developer/`](Documentation/Developer/) are welcome and are reviewed the
+same way as code.
+
+**Contribute code.** See the workflow below.
+
+## Before you start on code
+
+- **Open an issue first for anything substantial** — new features, dependency changes,
+  or changes that alter existing behavior. Small, self-contained bug fixes can go
+  straight to a pull request.
+- **Check that you can build and test the project.** Start with the
+  [Developer Guide](Documentation/Developer/DeveloperGuide.md), which covers
+  dependencies, configuring the build, and running the test suite.
+
+## Development workflow
+
+ITK-SNAP uses a fork-and-pull-request model.
+
+1. **Fork** <https://github.com/pyushkevich/itksnap> and clone your fork
+   **recursively** — ITK-SNAP has git submodules:
+
+   ```
+   git clone --recursive https://github.com/<your-username>/itksnap.git
+   ```
+
+2. **Create a topic branch** off `master` with a descriptive name:
+
+   ```
+   git checkout -b fix-polygon-tool-crash master
+   ```
+
+3. **Make your changes**, keeping the branch focused on one thing. Unrelated cleanups
+   in the same branch make review harder and are usually asked to be split out.
+
+4. **Build and test locally** before pushing (see the Developer Guide). At a minimum,
+   the project should build without new warnings on your platform and `ctest` should
+   show no new failures.
+
+5. **Push** to your fork and **open a pull request** against `master`.
+
+6. **Respond to review.** Push additional commits to the same branch; there is no need
+   to force-push unless you are asked to.
+
+## Commit messages
+
+ITK-SNAP follows the commit-message convention used across the ITK/VTK/3D Slicer
+ecosystem. Prefix the subject line with the kind of change:
+
+| Prefix   | Meaning                                                     |
+| -------- | ----------------------------------------------------------- |
+| `BUG:`   | Fix for a runtime defect                                     |
+| `ENH:`   | New functionality or an improvement to existing functionality |
+| `DOC:`   | Documentation only                                           |
+| `COMP:`  | Fix for a compiler or build error                            |
+| `PERF:`  | Performance improvement                                      |
+| `STYLE:` | Formatting or cosmetic change, no functional effect          |
+| `WIP:`   | Work in progress, not ready to merge                         |
+
+Guidelines:
+
+- Keep the subject line under 72 characters and write it in the imperative mood
+  ("Fix crash when closing a workspace", not "Fixed" or "Fixes").
+- Use the body to explain **what** the change does and **why**, not how — the diff
+  already shows how.
+- Reference the issue it addresses (`Fixes #123`) when there is one.
+
+Example:
+
+```
+BUG: Prevent crash when closing a workspace during mesh update
+
+Closing a workspace while a background mesh build was running left the
+Generic3DModel holding a dangling pointer to the destroyed image data.
+Wait for the mesh worker to finish before tearing down the model.
+
+Fixes #456
+```
+
+## What a pull request should contain
+
+- **A clear description** of the problem and the approach taken.
+- **Tests** for new functionality or for a bug fix, where the change is testable.
+  Test data lives in `Testing/TestData/`; GUI tests are driven by scripts under
+  `GUI/Qt/Resources/Scripts/`.
+- **No unrelated changes** — no reformatting of files you did not otherwise touch.
+- **Consistent formatting.** The repository has a `.clang-format` at its root; format
+  the lines you add or change. Please do not reformat whole existing files, as this
+  obscures history.
+- **Backward compatibility.** ITK-SNAP reads workspaces and images written by older
+  versions; changes to file formats, the workspace schema, or the command-line
+  interface need explicit discussion.
+
+## Continuous integration
+
+Every push and pull request is built by GitHub Actions on Linux, macOS (Intel and Apple
+Silicon), and Windows, and the test suite is run. A pull request is expected to be green
+before it is merged. If CI fails for a reason you believe is unrelated to your change,
+say so in the pull request rather than ignoring it.
+
+## Review and merging
+
+A maintainer will review your pull request. Because ITK-SNAP is maintained by a small
+team alongside other research commitments, please allow some time for a first response,
+and feel free to leave a polite reminder on the pull request if a week passes with no
+reply.
+
+Pull requests are merged by a maintainer once the review is resolved and CI is passing.
+See [GOVERNANCE.md](GOVERNANCE.md) for who the maintainers are.
+
+## Licensing
+
+ITK-SNAP is distributed under the **GNU General Public License, version 3** (see
+[`COPYING`](COPYING)). By submitting a contribution you agree that it may be distributed
+under that license. Please do not include code you do not have the right to contribute,
+or code taken from a project under an incompatible license.

--- a/Documentation/Developer/DeveloperGuide.md
+++ b/Documentation/Developer/DeveloperGuide.md
@@ -1,0 +1,379 @@
+# ITK-SNAP Developer Guide
+
+This guide is for people who want to build ITK-SNAP from source and change it. It covers
+getting the code, building it, running the tests, and finding your way around the
+codebase.
+
+If you are looking for how to *submit* a change, see
+[CONTRIBUTING.md](../../CONTRIBUTING.md). For who reviews and merges changes, see
+[GOVERNANCE.md](../../GOVERNANCE.md).
+
+**Contents**
+
+- [Getting the source](#getting-the-source)
+- [Dependencies](#dependencies)
+- [Building](#building)
+- [Running ITK-SNAP](#running-itk-snap)
+- [Running the tests](#running-the-tests)
+- [Architecture](#architecture)
+- [Key patterns](#key-patterns)
+- [Where to make common changes](#where-to-make-common-changes)
+- [Coding style](#coding-style)
+- [Further reading](#further-reading)
+
+---
+
+## Getting the source
+
+ITK-SNAP uses git submodules (`Submodules/c3d`, `Submodules/greedy`,
+`Submodules/digestible`), so clone recursively:
+
+```bash
+git clone --recursive https://github.com/pyushkevich/itksnap.git
+```
+
+If you already cloned without `--recursive`, fill in the submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+A build configured against a repository with empty submodule directories will fail in
+confusing ways. If CMake reports missing sources under `Submodules/`, this is why.
+
+## Dependencies
+
+ITK-SNAP is C++17 and requires CMake ≥ 3.16.
+
+| Dependency  | Minimum   | Notes                                                              |
+| ----------- | --------- | ------------------------------------------------------------------ |
+| ITK         | 5.4       | Built with the components ITK-SNAP requires; see `CMake/standalone.cmake` |
+| VTK         | 9.3.1     | Must include the `RenderingExternal` module (used by the 3D view)  |
+| Qt          | 6         | Components: Widgets, OpenGL, Concurrent, Qml, LinguistTools        |
+| libcurl     | —         | Remote image loading                                                |
+| libssh      | —         | SSH tunneling to remote deep-learning servers                       |
+
+Continuous integration builds against **ITK v5.4.0, VTK 9.5.2, and Qt 6.8.1** on Linux,
+macOS (Intel and Apple Silicon), and Windows. Those versions are the best-tested
+combination; the table above gives the floors that CMake enforces.
+
+Two dependency notes that cost people time:
+
+- **VTK must be built with `-DVTK_MODULE_ENABLE_VTK_RenderingExternal=YES`.** The 3D
+  render widget (`QtFrameBufferOpenGLWidget`) uses `vtkExternalOpenGLRenderWindow`. A VTK
+  build without this module configures fine and fails at link time.
+- **Use a consistent ITK build.** ITK uses `extern template`, so ITK-SNAP relies entirely
+  on the compiled ITK libraries rather than on headers alone. An ITK build directory whose
+  sources were updated without recompiling will produce undefined-symbol link errors that
+  look like ITK-SNAP bugs but are not.
+
+Prebuilt-dependency instructions for each platform are maintained on
+[the ITK-SNAP website](http://www.itksnap.org/pmwiki/pmwiki.php?n=Documentation.BuildingITK-SNAP).
+
+## Building
+
+ITK-SNAP builds out of source. Ninja is recommended:
+
+```bash
+mkdir build && cd build
+cmake -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DITK_DIR=/path/to/itk/lib/cmake/ITK-5.4 \
+  -DVTK_DIR=/path/to/vtk/lib/cmake/vtk-9.5 \
+  -DCMAKE_PREFIX_PATH=/path/to/qt6 \
+  ../itksnap
+ninja
+```
+
+Useful targets:
+
+```bash
+ninja ITK-SNAP     # the GUI application only
+ninja              # the "all" target: application, CLI tools, and test executables
+```
+
+**Build `all`, not just `ITK-SNAP`, before opening a pull request.** The test executables
+and the bundled command-line tools are only built by `all`, so `ninja ITK-SNAP` alone can
+leave a compile error undiscovered until CI finds it.
+
+**Use a fresh build directory when you change a dependency's major or minor version.**
+Reconfiguring an existing build tree across, say, a VTK 9.3 → 9.5 upgrade leaves stale
+cached paths and produces failures that are hard to attribute.
+
+## Running ITK-SNAP
+
+```bash
+./ITK-SNAP                       # or ITK-SNAP.app/Contents/MacOS/ITK-SNAP on macOS
+./ITK-SNAP -g image.nii.gz       # load a main image
+./ITK-SNAP -w workspace.itksnap  # load a workspace
+```
+
+On Linux without a display (for example over SSH), run under a virtual framebuffer:
+
+```bash
+xvfb-run -a ./ITK-SNAP
+```
+
+## Running the tests
+
+Tests are registered with CTest and run from the build directory:
+
+```bash
+ctest                          # everything
+ctest -R BasicSlicingTestX39   # one test by name
+ctest -V                       # verbose output
+ctest -j4                      # in parallel
+```
+
+On headless Linux, GUI tests need a virtual framebuffer:
+
+```bash
+xvfb-run -a ctest
+```
+
+The suite has two kinds of test:
+
+**Logic and unit tests** are standalone executables (`logic_api_test`, `testTDigest`,
+`TestLargeImageCheck`, the slicing tests) built from `Testing/Logic/` and driven by
+`itkTestDriver`.
+
+**GUI tests** drive the real application. Each is registered from the `GUI_TESTS` list in
+the top-level `CMakeLists.txt` and runs as:
+
+```bash
+./ITK-SNAP --test <TestName> --testdir <path-to>/Testing/TestData
+```
+
+The runner loads the script `Testing/GUI/Qt/Scripts/test_<TestName>.js`, compiled into the
+binary as a Qt resource via `Testing/GUI/Qt/TestingScripts.qrc`. To add a GUI test, add
+the script, register it in the `.qrc`, and add its name to `GUI_TESTS`. **The name in
+`GUI_TESTS` must match the script filename exactly** — a mismatch makes the test look for
+a script that does not exist, and a GUI test with no script reports as passing without
+running anything.
+
+Test data lives in `Testing/TestData/`. GUI tests have a 180-second timeout; on a slow
+machine, or under software rendering, set the CMake variable `SNAP_GUI_TEST_ACCEL` below
+`1.0` to slow the scripted interaction down proportionally.
+
+A few tests are sensitive to their environment. Tests under the `Remote` label need
+network access, and timing-sensitive GUI tests (notably the 4D replay and rendering tests)
+can fail under software OpenGL on a slow machine without indicating a real regression. If
+a test fails, check whether it also fails on unmodified `master` before assuming your
+change caused it.
+
+## Architecture
+
+ITK-SNAP is organized in three layers, with a shared infrastructure layer beneath them.
+The dependency direction is strictly one way: **Qt code may depend on models, models may
+depend on logic, and logic depends on neither.**
+
+```
+GUI/Qt/       Qt widgets, views, windows          — Qt, no ITK/VTK algorithms
+GUI/Renderer/ VTK and OpenGL scene renderers      — no Qt widget dependency
+GUI/Model/    presentation models                 — no Qt
+Logic/        image data, algorithms, IO          — no Qt, no GUI
+Common/       events, properties, shared types    — used by all of the above
+```
+
+Keeping `Logic/` free of Qt is a deliberate design decision, not an accident: it is what
+allows ITK-SNAP's core to be used from command-line tools and other front ends.
+
+### `Logic/` — computation and data
+
+No GUI dependencies at all.
+
+- `Logic/Framework/IRISApplication.cxx` — top-level application state; the entry point to
+  almost everything. Start reading here.
+- `Logic/Framework/IRISImageData.cxx`, `SNAPImageData.cxx` — the image containers for the
+  two application modes (see below).
+- `Logic/ImageWrapper/` — the `ImageWrapper<T>` abstraction over ITK images, plus display
+  policies, histograms, and slicing.
+- `Logic/Slicing/` — the 2D slice-extraction pipeline, OpenGL2-accelerated with a software
+  fallback.
+- `Logic/LevelSet/` — the snake/level-set segmentation algorithms.
+- `Logic/Mesh/` — VTK-based mesh generation and processing.
+- `Logic/Preprocessing/` — speed-image and preprocessing filters.
+- `Logic/WorkspaceAPI/` — the public API for reading and manipulating workspaces; also used
+  by the `itksnap-wt` command-line tool.
+- `Logic/RLEImage/` — run-length-encoded label image storage.
+
+### `GUI/Model/` — presentation models
+
+Mediates between `Logic/` and Qt widgets. Models derive from `AbstractModel` and expose
+their state as observable properties. **This layer must not include Qt widget headers**;
+it communicates outward through the property and event system, which is what keeps the
+GUI replaceable.
+
+### `GUI/Qt/` — presentation
+
+- `Windows/` — top-level windows and dialogs (`MainImageWindow` is the main one).
+- `Components/` — reusable widgets.
+- `View/` — the OpenGL-backed 2D slice views and 3D view.
+- `Coupling/` — the machinery binding model properties to Qt widgets (see below).
+- `ModelView/` — Qt item-model adapters.
+- `Resources/`, `Translations/` — icons, `.qrc` resources, and translation files.
+- `main.cxx` — application entry point.
+
+Slice-view interaction uses a strategy pattern: `CrosshairsInteractionMode`,
+`PaintbrushInteractionMode`, and their siblings share a common interface, and
+`InteractionModeClient` manages which one is active.
+
+### `GUI/Renderer/` — rendering
+
+`AbstractVTKRenderer` and `AbstractVTKSceneRenderer` decouple the VTK pipelines from the
+Qt widgets that host them. The 3D view renders through VTK; 2D slices use a custom OpenGL2
+renderer introduced in 4.4, with a software fallback for devices that cannot support it.
+
+### `Common/` — shared infrastructure
+
+- `AbstractModel.h` — base class for all models; ITK-style event firing.
+- `PropertyModel.h` — the typed, observable property system. Central to the whole GUI
+  model layer, and the single most useful header to understand.
+- `SNAPEvents.h` — event type definitions.
+- `Registry.cxx` — the hierarchical settings and serialization format used for
+  preferences and workspaces.
+- `IRISException.h` — the project's exception type.
+
+### `Submodules/`
+
+- `c3d/` — the Convert3D command-line tool.
+- `greedy/` — the Greedy deformable registration tool, used for registration and
+  segmentation propagation.
+- `digestible/` — t-digest, for approximate quantiles and histograms.
+
+## Key patterns
+
+### The property and coupling system
+
+This is the pattern you must understand to work on the GUI.
+
+A model exposes state as an `AbstractPropertyModel<T>` — a value that can be read, set,
+and observed. A *coupling* in `GUI/Qt/Coupling/` binds that property to a Qt widget in
+both directions: editing the widget writes through to the model, and a change in the model
+updates the widget. The model never mentions Qt, and the widget never reaches into the
+logic layer.
+
+In practice, a new user-visible option means: add the property to the relevant model in
+`GUI/Model/`, then make a single coupling call in the corresponding widget class rather
+than wiring signals and slots by hand.
+
+Changes propagate through ITK-style events defined in `Common/SNAPEvents.h`; events are
+batched in an `EventBucket` so that a burst of related changes causes one update rather
+than many.
+
+### `ImageWrapper`
+
+All image data is reached through `ImageWrapperBase` and its subclasses —
+`ScalarImageWrapper`, `VectorImageWrapper`, `LabelImageWrapper`. A wrapper owns a typed
+ITK image and adds what the application needs on top of it: display mapping, slice
+extraction, histograms, and metadata. Application code should work with wrappers rather
+than with raw `itk::Image` pointers.
+
+### IRIS mode and SNAP mode
+
+ITK-SNAP has two modes, and the distinction runs through the whole codebase:
+
+- **IRIS mode** — manual segmentation with the paintbrush, polygon, and other tools;
+  image data lives in `IRISImageData`.
+- **SNAP mode** — semi-automatic level-set segmentation on a sub-region of interest;
+  image data lives in `SNAPImageData`.
+
+`IRISApplication` owns both and manages the transition between them. When adding a
+feature, be explicit about which mode it applies to.
+
+### Memory ownership
+
+ITK-SNAP uses ITK smart pointers extensively, and the mixture of owning and non-owning
+pointers has historically been a source of leaks. Before adding new object relationships,
+read [MemoryManagement.md](MemoryManagement.md) — it documents the ownership patterns that
+caused past leaks and how to avoid repeating them.
+
+## Where to make common changes
+
+| You want to…                       | Start at                                                                 |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| Add a user-visible option          | The relevant model in `GUI/Model/`, then a coupling in the widget class   |
+| Add a menu item or dialog          | `GUI/Qt/Windows/`, plus a model to hold its state                         |
+| Change how a slice is rendered     | `Logic/Slicing/`, `GUI/Renderer/`, and `GUI/Qt/View/`                     |
+| Add or change an image IO path     | `Logic/ImageWrapper/` and the IO classes in `Logic/Framework/`            |
+| Add a segmentation algorithm       | `Logic/LevelSet/` or `Logic/Preprocessing/`                               |
+| Change workspace contents          | `Logic/WorkspaceAPI/` and `Common/Registry.cxx` — and read the note below |
+| Add a command-line option          | `GUI/Qt/main.cxx` and `Common/CommandLineArgumentParser.cxx`              |
+| Add a test                         | `Testing/Logic/` for unit tests, `Testing/GUI/Qt/Scripts/` for GUI tests  |
+
+**Workspaces and file formats deserve extra care.** ITK-SNAP opens workspaces written by
+much older versions, and users rely on that. Adding a field is usually safe; changing or
+removing the meaning of an existing one is not, and should be discussed in an issue first.
+
+### Registering a new header in CMakeLists.txt
+
+This one is easy to miss, because the build succeeds without it. When you add a header
+file, also add it to the appropriate list in the top-level `CMakeLists.txt`, so that it
+appears in IDE file browsers and search indexes and — for Qt headers — gets processed by
+`moc`:
+
+| List                 | For                                                                     |
+| -------------------- | ----------------------------------------------------------------------- |
+| `LOGIC_HEADERS`      | Headers under `Common/` and `Logic/`, and other toolkit-independent code |
+| `UI_MOC_HEADERS`     | Qt headers containing `Q_OBJECT` or `Q_GADGET` — these **must** be here  |
+| `UI_NONMOC_HEADERS`  | Qt-related headers with no `Q_OBJECT` (interfaces, coupling helpers)     |
+
+Entries within each list are sorted alphabetically by path. Source files are registered in
+the nearby `SNAP_CXX` and `UI_QT_CXX` blocks.
+
+### Executables
+
+| Target       | Entry point                              | Description                    |
+| ------------ | ---------------------------------------- | ------------------------------ |
+| `ITK-SNAP`   | `GUI/Qt/main.cxx`                        | The main GUI application       |
+| `itksnap-wt` | `Utilities/Workspace/WorkspaceTool.cxx`  | Command-line workspace tool    |
+
+## Coding style
+
+- **C++17.** The minimum standard is set in the top-level `CMakeLists.txt`.
+- **Use the project's ITK object conventions.** Logic and model classes derive from
+  `itk::Object`, declare their boilerplate with `irisITKObjectMacro(ClassName, SuperClass)`,
+  and are held in `SmartPtr<T>` (an alias for `itk::SmartPointer<T>`) and created with
+  `irisNew<T>(...)`. Reserve raw `new` for Qt widgets, which Qt's parent-child ownership
+  manages. Vector types come from `Common/IRISVectorTypes.h` (`Vector3d`, `Vector3ui`, …),
+  not from raw arrays.
+- **Route ITK events through the event bucket.** Connect ITK events to
+  `onModelUpdate(EventBucket &)` via `LatentITKEventNotifier::connect`, then dispatch
+  inside it with `b.HasEvent(SomeEvent(), source)`. Connecting an ITK event directly to a
+  dedicated slot that ignores the bucket defeats the coalescing and causes duplicate
+  handling.
+- **Formatting** is defined by the `.clang-format` file at the repository root (written
+  for clang-format 19.1.4). Format the lines you add or change. Do not reformat whole
+  files you are otherwise not modifying — it buries the real change in noise and destroys
+  `git blame`.
+- **Match the surrounding code.** The codebase spans two decades and its conventions are
+  not uniform; the CMake files in particular mix old-style (`SET`, `IF`) and modern
+  commands. Consistency within a file beats global consistency.
+- **Respect the layer boundaries.** No Qt headers in `Logic/` or `GUI/Model/`. If you find
+  yourself wanting one, the design is telling you the state belongs in a model.
+- **Portability.** The project builds with Clang, GCC, and MSVC. GCC and MSVC reject
+  constructs Clang accepts, so a change that compiles on macOS can still fail CI —
+  streaming a `std::string` into `qDebug()` and relying on transitive Qt includes are two
+  recurring examples.
+
+## Further reading
+
+Also in this directory:
+
+- [MemoryManagement.md](MemoryManagement.md) — owning vs. non-owning pointer patterns.
+- [MemoryLeakTestingMacOS.md](MemoryLeakTestingMacOS.md) — running `leaks` against a build
+  on macOS, and the expected baseline.
+- [RemoteURLs.md](RemoteURLs.md) — the remote-URL loading scheme.
+
+Elsewhere in the repository:
+
+- [`Documentation/DesignNotes/gui_design.txt`](../DesignNotes/gui_design.txt) — original
+  design notes for the GUI architecture.
+- [`ReleaseNotes.md`](../../ReleaseNotes.md) — what changed in each release.
+
+Online:
+
+- [Building ITK-SNAP](http://www.itksnap.org/pmwiki/pmwiki.php?n=Documentation.BuildingITK-SNAP)
+  — per-platform dependency instructions.
+- [Mailing lists](http://www.itksnap.org/pmwiki/pmwiki.php?n=MailingLists) — the users'
+  and developers' lists.

--- a/Documentation/Developer/README.md
+++ b/Documentation/Developer/README.md
@@ -1,0 +1,29 @@
+# ITK-SNAP Developer Documentation
+
+Documentation for people building and modifying ITK-SNAP. End-user documentation lives at
+[itksnap.org](http://www.itksnap.org/pmwiki/pmwiki.php?n=Documentation.HomePage).
+
+**Start here:**
+
+- **[DeveloperGuide.md](DeveloperGuide.md)** — building from source, running the tests, a
+  tour of the architecture, and where to make common kinds of change.
+
+**Reference:**
+
+- [MemoryManagement.md](MemoryManagement.md) — owning vs. non-owning pointer patterns, and
+  the ownership mistakes that caused past leaks.
+- [MemoryLeakTestingMacOS.md](MemoryLeakTestingMacOS.md) — running `leaks` against a local
+  build on macOS, including the expected baseline for the canary tests.
+- [RemoteURLs.md](RemoteURLs.md) — how ITK-SNAP loads images and workspaces from remote
+  URLs.
+
+**Design notes:**
+
+- [../DesignNotes/gui_design.txt](../DesignNotes/gui_design.txt) — original notes on the
+  GUI architecture.
+
+**Contributing:**
+
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — how to report bugs and submit pull requests.
+- [GOVERNANCE.md](../../GOVERNANCE.md) — how the project is run and who maintains it.
+- [CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md) — expectations for participation.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,91 @@
+# ITK-SNAP Governance
+
+This document describes how the ITK-SNAP project is currently run: who makes decisions,
+how contributions are accepted, and how releases are made. It describes existing
+practice rather than aspiration, and it will be revised as the project's governance
+develops.
+
+## Principles
+
+ITK-SNAP is free and open-source software, distributed under the
+[GNU General Public License, version 3](COPYING). Development happens in the open at
+<https://github.com/pyushkevich/itksnap>: the full source, issue tracker, and commit
+history are public, and anyone may participate by opening issues or pull requests.
+
+## Roles
+
+**Users** use ITK-SNAP and participate by asking questions on the
+[mailing lists](http://www.itksnap.org/pmwiki/pmwiki.php?n=MailingLists) and reporting
+bugs. Users are the project's most important source of feedback.
+
+**Contributors** submit changes — code, tests, or documentation — through pull requests.
+Anyone can become a contributor; see [CONTRIBUTING.md](CONTRIBUTING.md). Contributors do
+not have commit access to the main repository and work from forks.
+
+**Maintainers** review and merge pull requests, triage issues, and have commit access to
+the main repository. Maintainers are responsible for the technical direction and quality
+of the code they merge.
+
+**The lead maintainer** has final responsibility for the project: overall technical
+direction, resolving disagreements that maintainers cannot settle among themselves,
+deciding release contents and timing, and administering the project's repositories,
+website, and distribution channels.
+
+## Current maintainers
+
+| Name                 | GitHub          | Role            |
+| -------------------- | --------------- | --------------- |
+| Paul A. Yushkevich   | @pyushkevich    | Lead maintainer |
+| Jilei Hao            | @jilei-hao      | Maintainer      |
+
+ITK-SNAP is the product of more than twenty years of work by many researchers, engineers,
+and students. Contributors past and present are acknowledged on the
+[Credits page](http://itksnap.org/credits.php).
+
+## How decisions are made
+
+Most decisions are made informally and in public, in the issue or pull request where the
+work is being discussed. Where there is disagreement, the project seeks consensus among
+the people doing the work; if consensus is not reached, the lead maintainer decides.
+
+Changes that affect users beyond a single bug fix — new features, changes to file
+formats or the workspace schema, changes to the command-line interface, new external
+dependencies, or raising the minimum version of an existing dependency — should be
+raised in an issue before implementation, so that the discussion is public and on the
+record.
+
+## Contributions and merging
+
+Contributions from outside the maintainer group arrive as pull requests and are reviewed
+by a maintainer before being merged. Maintainers may commit routine work directly, and
+request review from each other for changes that are large, risky, or outside their
+usual area.
+
+Every push and pull request is built and tested on Linux, macOS, and Windows by GitHub
+Actions. Changes are expected to be green in CI before they are merged.
+
+## Releases
+
+ITK-SNAP uses `MAJOR.MINOR.PATCH` version numbers. The lead maintainer decides what goes
+into a release and when it ships, cuts the release, and publishes signed binary
+installers through the project's established distribution channels
+([itksnap.org](http://www.itksnap.org/download/snap) and SourceForge). Notable changes
+are recorded in [`ReleaseNotes.md`](ReleaseNotes.md).
+
+## Becoming a maintainer
+
+There is no formal application process. Maintainers are invited by the existing
+maintainers, on the basis of a sustained record of good contributions to the project and
+of helpful participation in review and discussion. Someone who wants to work toward this
+should start by contributing regularly and reviewing others' pull requests.
+
+## Limits of this document, and how it changes
+
+ITK-SNAP currently follows a **lead-maintainer model**, supported by a small core team.
+The project does not yet have a broader formal governance structure — no steering
+committee, no voting procedure, and no formal succession plan. How best to broaden
+governance, and to reduce the project's reliance on a single maintainer, is under active
+discussion; models such as the Insight Software Consortium are being considered.
+
+This document is versioned with the source code. Proposed changes should be made as pull
+requests and are approved by the lead maintainer.

--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ the stability and quality of this program:
 *   By reporting bugs and suggesting enhancements using the [Bug Tracker](http://www.itksnap.org/pmwiki/pmwiki.php?n=Main.BugTracker).
 *   By joining the ITK-SNAP Development Team on [SourceForge.net](http://sourceforge.net/projects/itk-snap) and contributing source code.
 
+### For Developers
+
+*   [Contributing Guidelines](CONTRIBUTING.md) — how to report bugs and submit pull requests.
+*   [Developer Guide](Documentation/Developer/DeveloperGuide.md) — building from source, running
+    the tests, and a tour of the architecture.
+*   [Governance](GOVERNANCE.md) — how the project is run and who maintains it.
+*   [Code of Conduct](CODE_OF_CONDUCT.md) — expectations for participation in the community.
+


### PR DESCRIPTION
Adds a first set of contributor and governance documentation. ITK-SNAP has none today — no `CONTRIBUTING.md`, `GOVERNANCE.md`, `CODE_OF_CONDUCT.md`, or developer guide anywhere in the repo.

Everything here is documentation only. No code, build, or test changes.

## What's added

| File | Contents |
|---|---|
| `CONTRIBUTING.md` | Reporting bugs, the fork/PR workflow, commit-message conventions, what makes a PR easy to review |
| `GOVERNANCE.md` | Roles, maintainer roster, how decisions are made, releases, becoming a maintainer |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 3.0, adapted |
| `Documentation/Developer/DeveloperGuide.md` | Building from source, running tests, architecture tour, where to make common changes |
| `Documentation/Developer/README.md` | Index over the new guide plus the three existing developer notes |

`README.md` gains a short "For Developers" section linking them.

## Two decisions that are yours, not mine

**1. `GOVERNANCE.md` describes you as lead maintainer** with final responsibility for technical direction, release contents and timing, and resolving disagreements. The maintainer roster is you and me. This matches how the project actually runs, but it is published under your name and should have your explicit agreement.

The document is deliberately descriptive rather than aspirational. It states plainly that there is no steering committee, no voting procedure, and no formal succession plan, and that broadening governance is under discussion. It makes no commitment the project does not already meet — so nothing in it can be contradicted by repo history.

**2. `CODE_OF_CONDUCT.md` names both of us as the reporting contacts,** using our institutional addresses, listed separately rather than behind one shared alias. The separation is deliberate: the document says a maintainer takes no part in deciding a report about themselves, and with two maintainers a single shared inbox would make that promise hollow.

One thing worth checking before merge: if Penn designates us as responsible employees for Title IX or similar, a report sent to a `@pennmedicine.upenn.edu` address may carry an escalation duty that conflicts with the confidentiality language in the document. If it applies, the fix is a disclosure sentence in the Reporting section, so a reporter knows before they write rather than after.

## Notes on the drafting

**Guidance is framed as recommendations, not requirements.** 8 of the last 60 commits on `master` carry a commit prefix, and most of those are merge commits — publishing a rule we do not follow ourselves would hold outside contributors to a standard the project ignores. The sections say so explicitly and note that we are trying the convention first. Backward compatibility keeps its weight, because that one is about not breaking workspaces users already have.

**Conventions are borrowed from ITK, VTK, and 3D Slicer** where they fit — the commit-prefix table, the fork-and-PR workflow, and the deliberately short Slicer-style governance document.

**Contributor Covenant 3.0** is the current release and a substantial rewrite of 2.1: Encouraged/Restricted Behaviors replace the old acceptable/unacceptable lists, and a four-rung enforcement ladder with a named repair path at each rung replaces the Community Impact Guidelines. Normative text is verbatim, verified against the upstream source. Note that 3.0 is licensed CC BY-SA 4.0 where 2.1 was CC BY 4.0 — this affects the code of conduct document only, not ITK-SNAP's GPL-3.0 licensing.

The developer guide is written against this branch's state: ITK ≥ 5.4, VTK ≥ 9.3.1, Qt6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)